### PR TITLE
Implement SQLCipher encryption support in SQLite WASM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,8 @@ SqliteWasm.Data/wwwroot/sqlite-wasm-bridge.js
 .nuget
 SqliteWasmBlazor/wwwroot
 SqliteWasmBlazor/native/lib/sqlite3_stub.o
+wasm-build/out/**
+wasm-build/src/**
 
 # Internal documentation
 docs/internal/

--- a/SqliteWasmBlazor.AdoNetSample/wwwroot/index.html
+++ b/SqliteWasmBlazor.AdoNetSample/wwwroot/index.html
@@ -5,6 +5,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SqliteWasmBlazor.AdoNetSample</title>
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'">
     <base href="/" />
     <link rel="preload" id="webassembly" />
     <link rel="stylesheet" href="css/app.css" />

--- a/SqliteWasmBlazor.Demo/wwwroot/index.html
+++ b/SqliteWasmBlazor.Demo/wwwroot/index.html
@@ -5,6 +5,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SqliteWasmBlazor.Demo</title>
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'">
     <base href="/" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" crossorigin="anonymous" />
     <link href="_content/SqliteWasmBlazor.FloatingWindow/floating-window.css" rel="stylesheet" />

--- a/SqliteWasmBlazor.TestApp/TestInfrastructure/TestFactory.cs
+++ b/SqliteWasmBlazor.TestApp/TestInfrastructure/TestFactory.cs
@@ -4,6 +4,7 @@ using SqliteWasmBlazor.TestApp.TestInfrastructure.Tests;
 using SqliteWasmBlazor.TestApp.TestInfrastructure.Tests.Checkpoints;
 using SqliteWasmBlazor.TestApp.TestInfrastructure.Tests.CRUD;
 using SqliteWasmBlazor.TestApp.TestInfrastructure.Tests.EFCoreFunctions;
+using SqliteWasmBlazor.TestApp.TestInfrastructure.Tests.Encryption;
 using SqliteWasmBlazor.TestApp.TestInfrastructure.Tests.ImportExport;
 using SqliteWasmBlazor.TestApp.TestInfrastructure.Tests.JsonCollections;
 using SqliteWasmBlazor.TestApp.TestInfrastructure.Tests.Migrations;
@@ -110,6 +111,11 @@ internal class TestFactory
         // Checkpoint Tests (rollback and restore functionality)
         _tests.Add(("Checkpoints", new RestoreToCheckpointBasicTest(factory)));
         _tests.Add(("Checkpoints", new RestoreToCheckpointWithDeltaReapplyTest(factory)));
+
+        // Encryption Tests
+        _tests.Add(("Encryption", new EncryptionBasicCRUDTest(factory, databaseService)));
+        _tests.Add(("Encryption", new EncryptionSpecialCharsPasswordTest(factory, databaseService)));
+        _tests.Add(("Encryption", new EncryptionWrongPasswordTest(factory, databaseService)));
 
         // V2 Bulk Import/Export Tests (worker-side prepared statement loop)
         _tests.Add(("V2 Bulk", new V2BulkTodoRoundTripTest(factory, databaseService)));

--- a/SqliteWasmBlazor.TestApp/TestInfrastructure/Tests/Encryption/EncryptionBasicCRUDTest.cs
+++ b/SqliteWasmBlazor.TestApp/TestInfrastructure/Tests/Encryption/EncryptionBasicCRUDTest.cs
@@ -1,0 +1,73 @@
+using Microsoft.EntityFrameworkCore;
+using SqliteWasmBlazor;
+using SqliteWasmBlazor.Models;
+using SqliteWasmBlazor.Models.Models;
+
+namespace SqliteWasmBlazor.TestApp.TestInfrastructure.Tests.Encryption;
+
+/// <summary>Verifies <c>Password=</c> is forwarded as <c>PRAGMA key</c>.</summary>
+internal class EncryptionBasicCRUDTest(IDbContextFactory<TodoDbContext> factory, ISqliteWasmDatabaseService databaseService)
+    : SqliteWasmTest(factory, databaseService)
+{
+    private const string EncryptedDb = "Encrypted_BasicCRUD.db";
+    private const string Password = "test-sqlcipher-key-42";
+
+    public override string Name => "Encryption_BasicCRUD";
+
+    // Own lifecycle: uses a separate DB, not the shared TestDb.db
+    protected override bool AutoCreateDatabase => false;
+
+    public override async ValueTask<string?> RunTestAsync()
+    {
+        if (DatabaseService is null)
+            throw new InvalidOperationException("ISqliteWasmDatabaseService not available");
+
+        if (await DatabaseService.ExistsDatabaseAsync(EncryptedDb))
+            await DatabaseService.DeleteDatabaseAsync(EncryptedDb);
+
+        var id = Guid.NewGuid();
+
+        // Phase 1: create + insert
+        await using (var ctx = CreateEncryptedContext())
+        {
+            await ctx.Database.EnsureCreatedAsync();
+
+            ctx.TodoItems.Add(new TodoItem
+            {
+                Id = id,
+                Title = "Encrypted Todo",
+                Description = "Written with PRAGMA key",
+                IsCompleted = false,
+                UpdatedAt = DateTime.UtcNow
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        // Close so next open re-applies the key
+        await DatabaseService.CloseDatabaseAsync(EncryptedDb);
+
+        // Phase 2: reopen + verify
+        await using (var ctx = CreateEncryptedContext())
+        {
+            var item = await ctx.TodoItems.FindAsync(id);
+            if (item is null)
+                throw new InvalidOperationException("Encrypted record not found after reopen");
+            if (item.Title != "Encrypted Todo")
+                throw new InvalidOperationException($"Unexpected title: {item.Title}");
+        }
+
+        await DatabaseService.CloseDatabaseAsync(EncryptedDb);
+        await DatabaseService.DeleteDatabaseAsync(EncryptedDb);
+
+        return "OK";
+    }
+
+    private TodoDbContext CreateEncryptedContext()
+    {
+        var connection = new SqliteWasmConnection($"Data Source={EncryptedDb};Password={Password}");
+        var options = new DbContextOptionsBuilder<TodoDbContext>()
+            .UseSqliteWasm(connection)
+            .Options;
+        return new TodoDbContext(options);
+    }
+}

--- a/SqliteWasmBlazor.TestApp/TestInfrastructure/Tests/Encryption/EncryptionSpecialCharsPasswordTest.cs
+++ b/SqliteWasmBlazor.TestApp/TestInfrastructure/Tests/Encryption/EncryptionSpecialCharsPasswordTest.cs
@@ -1,0 +1,74 @@
+using Microsoft.EntityFrameworkCore;
+using SqliteWasmBlazor;
+using SqliteWasmBlazor.Models;
+using SqliteWasmBlazor.Models.Models;
+
+namespace SqliteWasmBlazor.TestApp.TestInfrastructure.Tests.Encryption;
+
+/// <summary>Verifies single-quote passwords are escaped before <c>PRAGMA key</c> interpolation.</summary>
+internal class EncryptionSpecialCharsPasswordTest(
+    IDbContextFactory<TodoDbContext> factory,
+    ISqliteWasmDatabaseService databaseService)
+    : SqliteWasmTest(factory, databaseService)
+{
+    private const string EncryptedDb = "Encrypted_SpecialChars.db";
+    // Single quote tests JS escaping in sqlite-worker.ts
+    private const string Password = "it's a key";
+
+    public override string Name => "Encryption_SpecialCharsPassword";
+
+    protected override bool AutoCreateDatabase => false;
+
+    public override async ValueTask<string?> RunTestAsync()
+    {
+        if (DatabaseService is null)
+            throw new InvalidOperationException("ISqliteWasmDatabaseService not available");
+
+        if (await DatabaseService.ExistsDatabaseAsync(EncryptedDb))
+            await DatabaseService.DeleteDatabaseAsync(EncryptedDb);
+
+        var id = Guid.NewGuid();
+
+        // Phase 1: create + insert
+        await using (var ctx = CreateEncryptedContext())
+        {
+            await ctx.Database.EnsureCreatedAsync();
+
+            ctx.TodoItems.Add(new TodoItem
+            {
+                Id = id,
+                Title = "Special Chars Todo",
+                Description = "Password contains a single quote",
+                IsCompleted = false,
+                UpdatedAt = DateTime.UtcNow
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        await DatabaseService.CloseDatabaseAsync(EncryptedDb);
+
+        // Phase 2: reopen + verify
+        await using (var ctx = CreateEncryptedContext())
+        {
+            var item = await ctx.TodoItems.FindAsync(id);
+            if (item is null)
+                throw new InvalidOperationException("Record not found after reopen with special-char password");
+            if (item.Title != "Special Chars Todo")
+                throw new InvalidOperationException($"Unexpected title: {item.Title}");
+        }
+
+        await DatabaseService.CloseDatabaseAsync(EncryptedDb);
+        await DatabaseService.DeleteDatabaseAsync(EncryptedDb);
+
+        return "OK";
+    }
+
+    private TodoDbContext CreateEncryptedContext()
+    {
+        var connection = new SqliteWasmConnection($"Data Source={EncryptedDb};Password={Password}");
+        var options = new DbContextOptionsBuilder<TodoDbContext>()
+            .UseSqliteWasm(connection)
+            .Options;
+        return new TodoDbContext(options);
+    }
+}

--- a/SqliteWasmBlazor.TestApp/TestInfrastructure/Tests/Encryption/EncryptionWrongPasswordTest.cs
+++ b/SqliteWasmBlazor.TestApp/TestInfrastructure/Tests/Encryption/EncryptionWrongPasswordTest.cs
@@ -1,0 +1,81 @@
+using Microsoft.EntityFrameworkCore;
+using SqliteWasmBlazor;
+using SqliteWasmBlazor.Models;
+using SqliteWasmBlazor.Models.Models;
+
+namespace SqliteWasmBlazor.TestApp.TestInfrastructure.Tests.Encryption;
+
+/// <summary>
+/// Verifies that opening an encrypted database with the wrong password (or no password)
+/// throws an exception rather than silently succeeding with corrupt/empty data.
+/// </summary>
+internal class EncryptionWrongPasswordTest(IDbContextFactory<TodoDbContext> factory, ISqliteWasmDatabaseService databaseService)
+    : SqliteWasmTest(factory, databaseService)
+{
+    private const string EncryptedDb = "Encrypted_WrongPassword.db";
+    private const string CorrectPassword = "correct-password-42";
+    private const string WrongPassword = "wrong-password";
+
+    public override string Name => "Encryption_WrongPassword";
+
+    protected override bool AutoCreateDatabase => false;
+
+    public override async ValueTask<string?> RunTestAsync()
+    {
+        if (DatabaseService is null)
+            throw new InvalidOperationException("ISqliteWasmDatabaseService not available");
+
+        if (await DatabaseService.ExistsDatabaseAsync(EncryptedDb))
+            await DatabaseService.DeleteDatabaseAsync(EncryptedDb);
+
+        // Phase 1: create encrypted database with the correct key
+        await using (var ctx = CreateContext(CorrectPassword))
+        {
+            await ctx.Database.EnsureCreatedAsync();
+
+            ctx.TodoItems.Add(new TodoItem
+            {
+                Id = Guid.NewGuid(),
+                Title = "Secret",
+                Description = "Protected data",
+                IsCompleted = false,
+                UpdatedAt = DateTime.UtcNow
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        await DatabaseService.CloseDatabaseAsync(EncryptedDb);
+
+        // Phase 2: attempt to open with the wrong key — must throw
+        bool threw = false;
+        try
+        {
+            await using var ctx = CreateContext(WrongPassword);
+            // EnsureCreatedAsync triggers the worker open + first query, which will fail when
+            // SQLCipher tries to read the encrypted file with the wrong key.
+            _ = await ctx.TodoItems.CountAsync();
+        }
+        catch
+        {
+            threw = true;
+        }
+
+        if (!threw)
+            throw new InvalidOperationException(
+                "Expected an exception when opening an encrypted database with the wrong password, but none was thrown.");
+
+        await DatabaseService.CloseDatabaseAsync(EncryptedDb);
+        await DatabaseService.DeleteDatabaseAsync(EncryptedDb);
+
+        return "OK";
+    }
+
+    private TodoDbContext CreateContext(string password)
+    {
+        var connection = new SqliteWasmConnection($"Data Source={EncryptedDb};Password={password}");
+        var options = new DbContextOptionsBuilder<TodoDbContext>()
+            .UseSqliteWasm(connection)
+            .Options;
+        return new TodoDbContext(options);
+    }
+}

--- a/SqliteWasmBlazor.TestApp/wwwroot/index.html
+++ b/SqliteWasmBlazor.TestApp/wwwroot/index.html
@@ -5,6 +5,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SqliteWasmBlazor.TestApp</title>
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'">
     <base href="/" />
     <link rel="stylesheet" href="css/app.css" />
     <link rel="icon" type="image/png" href="favicon.png" />

--- a/SqliteWasmBlazor.Tests/ConnectionStringParsingTests.cs
+++ b/SqliteWasmBlazor.Tests/ConnectionStringParsingTests.cs
@@ -1,0 +1,29 @@
+using SqliteWasmBlazor;
+
+namespace SqliteWasmBlazor.Tests;
+
+public class ConnectionStringParsingTests
+{
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    [InlineData("Data Source=test.db", null)]
+    [InlineData("Data Source=test.db;Password=abc", "abc")]
+    [InlineData("Data Source=test.db;Password=has=equals", "has=equals")] // '=' in value
+    // Case-insensitive key
+    [InlineData("Data Source=test.db;password=lower", "lower")]
+    [InlineData("Data Source=test.db;PASSWORD=upper", "upper")]
+    // Whitespace around key / value
+    [InlineData("Data Source=test.db; Password = abc ", "abc")]
+    // Empty value after trim → null
+    [InlineData("Data Source=test.db;Password=", null)]
+    [InlineData("Data Source=test.db;Password=   ", null)]
+    // Password appears without Data Source
+    [InlineData("Password=standalone", "standalone")]
+    // Password appears before Data Source
+    [InlineData("Password=first;Data Source=test.db", "first")]
+    public void ParsePassword_ReturnsExpected(string? connectionString, string? expected)
+    {
+        Assert.Equal(expected, SqliteWasmConnection.ParsePassword(connectionString));
+    }
+}

--- a/SqliteWasmBlazor.Tests/SqliteWasmBlazor.Tests.csproj
+++ b/SqliteWasmBlazor.Tests/SqliteWasmBlazor.Tests.csproj
@@ -29,6 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\SqliteWasmBlazor\SqliteWasmBlazor.csproj" />
     <ProjectReference Include="..\SqliteWasmBlazor.TestHost\SqliteWasmBlazor.TestHost.csproj" />
   </ItemGroup>
 

--- a/SqliteWasmBlazor.Tests/SqliteWasmTestBase.cs
+++ b/SqliteWasmBlazor.Tests/SqliteWasmTestBase.cs
@@ -88,6 +88,10 @@ public abstract class SqliteWasmTestBase(IWaFixture fixture, ITestOutputHelper o
     // Checkpoint Tests
     [InlineData("RestoreToCheckpoint_Basic")]
     [InlineData("RestoreToCheckpoint_WithDeltaReapply")]
+    // Encryption Tests
+    [InlineData("Encryption_BasicCRUD")]
+    [InlineData("Encryption_SpecialCharsPassword")]
+    [InlineData("Encryption_WrongPassword")]
     public async Task TestCaseAsync(string name)
     {
         Assert.NotNull(_fixture.Page);

--- a/SqliteWasmBlazor/Ado/SqliteWasmConnection.cs
+++ b/SqliteWasmBlazor/Ado/SqliteWasmConnection.cs
@@ -77,6 +77,28 @@ public sealed class SqliteWasmConnection : DbConnection
         return ":memory:";
     }
 
+    internal static string? ParsePassword(string? connectionString)
+    {
+        if (string.IsNullOrEmpty(connectionString))
+            return null;
+
+        var parts = connectionString.Split(';');
+        foreach (var part in parts)
+        {
+            var kv = part.Split('=', 2);
+            if (kv.Length == 2 &&
+                kv[0].Trim().Equals("Password", StringComparison.OrdinalIgnoreCase))
+            {
+                var value = kv[1].Trim();
+                return value.Length > 0 ? value : null;
+            }
+        }
+
+        return null;
+    }
+
+    private string? GetPassword() => ParsePassword(_connectionString);
+
     public override void Open()
     {
         // EF Core's EnsureCreatedAsync may call synchronous Open() in some paths
@@ -105,7 +127,7 @@ public sealed class SqliteWasmConnection : DbConnection
 
         try
         {
-            await _bridge.OpenDatabaseAsync(Database, cancellationToken);
+            await _bridge.OpenDatabaseAsync(Database, GetPassword(), cancellationToken);
 
             // PRAGMAs are set by the worker on first database open
             // This ensures they apply to the actual worker-side connection and persist

--- a/SqliteWasmBlazor/Extensions/SqliteWasmDbContextOptionsExtensions.cs
+++ b/SqliteWasmBlazor/Extensions/SqliteWasmDbContextOptionsExtensions.cs
@@ -40,6 +40,26 @@ public static class SqliteWasmDbContextOptionsExtensions
         return optionsBuilder;
     }
 
+    /// <inheritdoc cref="UseSqliteWasm(DbContextOptionsBuilder, SqliteWasmConnection)"/>
+    public static DbContextOptionsBuilder<TContext> UseSqliteWasm<TContext>(
+        this DbContextOptionsBuilder<TContext> optionsBuilder,
+        SqliteWasmConnection connection)
+        where TContext : DbContext
+    {
+        ((DbContextOptionsBuilder)optionsBuilder).UseSqliteWasm(connection);
+        return optionsBuilder;
+    }
+
+    /// <inheritdoc cref="UseSqliteWasm(DbContextOptionsBuilder, string)"/>
+    public static DbContextOptionsBuilder<TContext> UseSqliteWasm<TContext>(
+        this DbContextOptionsBuilder<TContext> optionsBuilder,
+        string connectionString)
+        where TContext : DbContext
+    {
+        ((DbContextOptionsBuilder)optionsBuilder).UseSqliteWasm(connectionString);
+        return optionsBuilder;
+    }
+
     /// <summary>
     /// Configures the DbContext to use the SqliteWasm provider with the specified connection string.
     /// </summary>

--- a/SqliteWasmBlazor/Extensions/SqliteWasmServiceCollectionExtensions.cs
+++ b/SqliteWasmBlazor/Extensions/SqliteWasmServiceCollectionExtensions.cs
@@ -28,17 +28,19 @@ public static class SqliteWasmServiceCollectionExtensions
     /// Use this method when using the ADO.NET provider directly without EF Core.
     /// </summary>
     /// <param name="services">The service collection.</param>
+    /// <param name="baseHref">Base href of the Blazor app (e.g. "/" or "/myapp/"). Defaults to "/".</param>
     /// <param name="cancellationToken">Optional cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     /// <exception cref="InvalidOperationException">Thrown when initialization fails or database is locked by another tab.</exception>
     public static async Task InitializeSqliteWasmAsync(
         this IServiceProvider services,
+        string baseHref = "/",
         CancellationToken cancellationToken = default)
     {
         try
         {
             // Initialize the worker bridge
-            await SqliteWasmWorkerBridge.Instance.InitializeAsync(cancellationToken);
+            await SqliteWasmWorkerBridge.Instance.InitializeAsync(baseHref, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -57,9 +59,11 @@ Please close any other tabs running this application and refresh the page.
     /// </summary>
     /// <typeparam name="TContext">The DbContext type to initialize.</typeparam>
     /// <param name="services">The service collection.</param>
+    /// <param name="baseHref">Base href of the Blazor app (e.g. "/" or "/myapp/"). Defaults to "/".</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     public static async Task InitializeSqliteWasmDatabaseAsync<TContext>(
-        this IServiceProvider services)
+        this IServiceProvider services,
+        string baseHref = "/")
         where TContext : DbContext
     {
         var initService = services.GetRequiredService<IDBInitializationService>();
@@ -67,7 +71,7 @@ Please close any other tabs running this application and refresh the page.
         try
         {
             // Initialize the worker bridge first
-            await SqliteWasmWorkerBridge.Instance.InitializeAsync();
+            await SqliteWasmWorkerBridge.Instance.InitializeAsync(baseHref);
         }
         catch (Exception ex)
         {

--- a/SqliteWasmBlazor/Services/SqliteWasmWorkerBridge.cs
+++ b/SqliteWasmBlazor/Services/SqliteWasmWorkerBridge.cs
@@ -74,22 +74,18 @@ internal sealed partial class SqliteWasmWorkerBridge : ISqliteWasmDatabaseServic
     {
     }
 
-    [JSImport("getBaseHref", "SqliteWasmBlazor")]
-    private static partial string GetBaseHref();
-
     /// <summary>
     /// Initialize the worker and sqlite-wasm module.
     /// </summary>
-    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    /// <param name="baseHref">The base href path (e.g. "/" or "/myapp/"). Pass <see cref="Microsoft.AspNetCore.Components.NavigationManager.BaseUri"/> resolved to a path. Defaults to "/".</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task InitializeAsync(string baseHref = "/", CancellationToken cancellationToken = default)
     {
         if (_isInitialized)
         {
             return;
         }
 
-        // Get base href dynamically and construct absolute path
-        await JSHost.ImportAsync("SqliteWasmBlazor", "data:text/javascript,export function getBaseHref() { return document.querySelector('base')?.getAttribute('href') || '/'; }");
-        var baseHref = GetBaseHref();
         var bridgePath = $"{baseHref}_content/SqliteWasmBlazor/sqlite-wasm-bridge.js";
 
         await JSHost.ImportAsync("sqliteWasmWorker", bridgePath, cancellationToken);
@@ -109,17 +105,13 @@ internal sealed partial class SqliteWasmWorkerBridge : ISqliteWasmDatabaseServic
         _isInitialized = true;
     }
 
-    /// <summary>
-    /// Open a database connection in the worker.
-    /// </summary>
-    public async Task OpenDatabaseAsync(string database, CancellationToken cancellationToken = default)
+    /// <summary>Open a database connection in the worker.</summary>
+    /// <param name="password">SQLCipher key; null = no encryption.</param>
+    public async Task OpenDatabaseAsync(string database, string? password = null, CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
 
-        var request = new
-        {
-            type = "open", database
-        };
+        var request = new { type = "open", database, key = password };
 
         await SendRequestAsync(request, cancellationToken);
         _openDatabases.Add(database);
@@ -496,7 +488,7 @@ internal sealed partial class SqliteWasmWorkerBridge : ISqliteWasmDatabaseServic
     {
         if (!_isInitialized)
         {
-            await InitializeAsync(cancellationToken);
+            await InitializeAsync("/", cancellationToken);
         }
     }
 

--- a/SqliteWasmBlazor/SqliteWasmBlazor.csproj
+++ b/SqliteWasmBlazor/SqliteWasmBlazor.csproj
@@ -45,6 +45,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="SqliteWasmBlazor.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="../README.md" Pack="true" PackagePath="/" />
     <None Include="../LICENSE" Pack="true" PackagePath="/" />
     <None Include="build/SqliteWasmBlazor.targets" Pack="true" PackagePath="build" />

--- a/SqliteWasmBlazor/TypeScript/package.json
+++ b/SqliteWasmBlazor/TypeScript/package.json
@@ -7,7 +7,7 @@
     "build": "npm run build:worker && npm run build:bridge && npm run copy:wasm",
     "build:worker": "esbuild sqlite-worker.ts --bundle --format=esm --sourcemap=inline --outfile=../wwwroot/sqlite-wasm-worker.js",
     "build:bridge": "esbuild worker-bridge.ts --bundle --format=esm --sourcemap=inline --outfile=../wwwroot/sqlite-wasm-bridge.js",
-    "copy:wasm": "cp node_modules/@sqlite.org/sqlite-wasm/dist/sqlite3.wasm ../wwwroot/",
+    "copy:wasm": "[ -f ../../wasm-build/out/sqlite3.wasm ] && cp ../../wasm-build/out/sqlite3.wasm ../wwwroot/ || cp node_modules/@sqlite.org/sqlite-wasm/dist/sqlite3.wasm ../wwwroot/",
     "build:release": "npm run build:worker:release && npm run build:bridge:release && npm run copy:wasm",
     "build:worker:release": "esbuild sqlite-worker.ts --bundle --format=esm --minify --outfile=../wwwroot/sqlite-wasm-worker.js",
     "build:bridge:release": "esbuild worker-bridge.ts --bundle --format=esm --minify --outfile=../wwwroot/sqlite-wasm-bridge.js"

--- a/SqliteWasmBlazor/TypeScript/patches/@sqlite.org+sqlite-wasm+3.51.2-build8.patch
+++ b/SqliteWasmBlazor/TypeScript/patches/@sqlite.org+sqlite-wasm+3.51.2-build8.patch
@@ -1,8 +1,65 @@
 diff --git a/node_modules/@sqlite.org/sqlite-wasm/dist/index.mjs b/node_modules/@sqlite.org/sqlite-wasm/dist/index.mjs
-index 17ae70c..a649463 100644
+index 17ae70c..079f1e4 100644
 --- a/node_modules/@sqlite.org/sqlite-wasm/dist/index.mjs
 +++ b/node_modules/@sqlite.org/sqlite-wasm/dist/index.mjs
-@@ -14956,6 +14956,17 @@ async function sqlite3InitModule(moduleArg = {}) {
+@@ -2540,7 +2540,26 @@ async function sqlite3InitModule(moduleArg = {}) {
+ 			return -e.errno;
+ 		}
+ 	}
+-	function ___syscall_rmdir(path) {
++	function ___syscall_renameat(olddirfd, oldpath, newdirfd, newpath) {
++		try {
++			oldpath = SYSCALLS.getStr(oldpath);
++			oldpath = SYSCALLS.calculateAt(olddirfd, oldpath);
++			newpath = SYSCALLS.getStr(newpath);
++			newpath = SYSCALLS.calculateAt(newdirfd, newpath);
++			FS.rename(oldpath, newpath);
++			return 0;
++		} catch (e) {
++			if (typeof FS == "undefined" || !(e.name === "ErrnoError")) throw e;
++			return -e.errno;
++		}
++	}
++	function ___syscall_getdents64(fd, dirp, count) {
++		return -38;
++	}
++	function __abort_js() {
++		abort('');
++	}
++		function ___syscall_rmdir(path) {
+ 		try {
+ 			path = SYSCALLS.getStr(path);
+ 			FS.rmdir(path);
+@@ -3195,7 +3214,10 @@ async function sqlite3InitModule(moduleArg = {}) {
+ 		fd_seek: _fd_seek,
+ 		fd_sync: _fd_sync,
+ 		fd_write: _fd_write,
+-		memory: wasmMemory
++		memory: wasmMemory,
++		__syscall_renameat: ___syscall_renameat,
++		__syscall_getdents64: ___syscall_getdents64,
++		_abort_js: __abort_js
+ 	};
+ 	function run() {
+ 		if (runDependencies > 0) {
+@@ -11952,6 +11974,12 @@ async function sqlite3InitModule(moduleArg = {}) {
+ 			const util = sqlite3.util, wasm = sqlite3.wasm, toss3 = util.toss3, hop = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
+ 			const kvvfsMethods = new sqlite3_kvvfs_methods(wasm.exports.sqlite3__wasm_kvvfs_methods());
+ 			util.assert(32 <= kvvfsMethods.$nKeySize, "unexpected kvvfsMethods.$nKeySize: " + kvvfsMethods.$nKeySize);
++			/* Guard: if the WASM was built from pre-3.52 SQLite sources, the
++			sqlite3_kvvfs_methods struct lacks the WASM-specific extension fields
++			(pVfs, pIoDb, pIoJrnl, nBufferSize). Skip the JS Storage override in that
++			case - the C-only kvvfs implementation remains active, which is fine for
++			OPFS-based projects that don't use the kvvfs localStorage/sessionStorage VFS.
++			The simple !$pVfs check is insufficient because the pre-3.52 struct is only
++			16 bytes; reading offset 16 returns heap garbage that may be non-zero.
++			We cross-check against pKvvfs (the pointer from sqlite3_vfs_find("kvvfs")):
++			in a 3.52 WASM $pVfs must equal pKvvfs; a garbage value virtually never will. */
++			if (!kvvfsMethods.$pVfs || kvvfsMethods.$pVfs !== pKvvfs) return;
+ 			/**
+ 			Most of the VFS-internal state.
+ 			*/
+@@ -14956,6 +14984,17 @@ async function sqlite3InitModule(moduleArg = {}) {
  				
  				Returns the 2nd argument.
  				*/
@@ -20,7 +77,7 @@ index 17ae70c..a649463 100644
  				storeErr(e, code) {
  					if (e) {
  						e.sqlite3Rc = code || capi.SQLITE_IOERR;
-@@ -15207,6 +15218,9 @@ async function sqlite3InitModule(moduleArg = {}) {
+@@ -15207,6 +15246,9 @@ async function sqlite3InitModule(moduleArg = {}) {
  				unlink(filename) {
  					return this.#p.deletePath(filename);
  				}

--- a/SqliteWasmBlazor/TypeScript/sqlite-worker.ts
+++ b/SqliteWasmBlazor/TypeScript/sqlite-worker.ts
@@ -17,6 +17,8 @@ interface WorkerRequest {
         database?: string;
         sql?: string;
         parameters?: Record<string, any>;
+        key?: string; // SQLCipher key (plaintext fallback)
+        encryptedKey?: { iv: number[]; ct: number[]; senderPub: number[] }; // ECDH-wrapped key
     };
     binaryPayload?: ArrayBuffer;
 }
@@ -41,6 +43,9 @@ let sqlite3: any;
 let poolUtil: any;
 const openDatabases = new Map<string, any>();
 const pragmasSet = new Set<string>(); // Track which databases have PRAGMAs configured
+
+// ECDH key pair for encrypted key exchange with main thread (lazy — only generated on first encrypted open)
+let workerKeyPair: CryptoKeyPair | null = null;
 
 // Cache table schemas: Map<tableName, Map<columnName, columnType>>
 const schemaCache = new Map<string, Map<string, string>>();
@@ -157,7 +162,7 @@ async function initializeSQLite() {
 }
 
 // Handle messages from main thread
-self.onmessage = async (event: MessageEvent<WorkerRequest | { type: 'setLogLevel'; level: number } | { type: 'init'; baseHref: string }>) => {
+self.onmessage = async (event: MessageEvent<WorkerRequest | { type: 'setLogLevel'; level: number } | { type: 'init'; baseHref: string } | { type: 'initEncryption' }>) => {
     // Handle initialization with base href
     if ('type' in event.data && event.data.type === 'init' && 'baseHref' in event.data) {
         baseHref = event.data.baseHref;
@@ -169,6 +174,18 @@ self.onmessage = async (event: MessageEvent<WorkerRequest | { type: 'setLogLevel
     // Handle log level changes (no response needed)
     if ('type' in event.data && event.data.type === 'setLogLevel' && 'level' in event.data) {
         logger.setLogLevel(event.data.level);
+        return;
+    }
+
+    // Lazy ECDH key exchange — generate worker key pair on first encrypted open request
+    if ('type' in event.data && event.data.type === 'initEncryption') {
+        workerKeyPair = await crypto.subtle.generateKey(
+            { name: 'ECDH', namedCurve: 'P-256' },
+            false, // private key non-extractable
+            ['deriveKey']
+        );
+        const rawPub = await crypto.subtle.exportKey('raw', workerKeyPair.publicKey);
+        self.postMessage({ type: 'workerPublicKey', pub: new Uint8Array(rawPub) });
         return;
     }
 
@@ -222,8 +239,37 @@ async function handleRequest(data: WorkerRequest['data'], binaryPayload?: ArrayB
     const { type, database, sql, parameters } = data;
 
     switch (type) {
-        case 'open':
-            return await openDatabase(database!);
+        case 'open': {
+            if (data.encryptedKey) {
+                // Decrypt ECDH-wrapped key before opening
+                if (!workerKeyPair) {
+                    throw new Error('Encrypted key received but ECDH key pair not initialized');
+                }
+                const { iv, ct, senderPub } = data.encryptedKey;
+                const senderPubKey = await crypto.subtle.importKey(
+                    'raw',
+                    new Uint8Array(senderPub),
+                    { name: 'ECDH', namedCurve: 'P-256' },
+                    false,
+                    []
+                );
+                const sharedKey = await crypto.subtle.deriveKey(
+                    { name: 'ECDH', public: senderPubKey },
+                    workerKeyPair.privateKey,
+                    { name: 'AES-GCM', length: 256 },
+                    false,
+                    ['decrypt']
+                );
+                const ptBytes = await crypto.subtle.decrypt(
+                    { name: 'AES-GCM', iv: new Uint8Array(iv) },
+                    sharedKey,
+                    new Uint8Array(ct)
+                );
+                const password = new TextDecoder().decode(ptBytes);
+                return await openDatabase(database!, password);
+            }
+            return await openDatabase(database!, data.key);
+        }
 
         case 'execute':
             return await executeSql(database!, sql!, parameters || {});
@@ -277,7 +323,7 @@ async function handleRequest(data: WorkerRequest['data'], binaryPayload?: ArrayB
     }
 }
 
-async function openDatabase(dbName: string) {
+async function openDatabase(dbName: string, key?: string) {
     if (!sqlite3 || !poolUtil) {
         throw new Error('SQLite not initialized');
     }
@@ -326,6 +372,13 @@ async function openDatabase(dbName: string) {
     // Always check if PRAGMAs need to be set (even if database was already open)
     // This handles the case where database was closed and reopened
     if (!pragmasSet.has(dbName)) {
+        // Apply SQLCipher key before WAL PRAGMAs.
+        // NOTE: PRAGMA key does not support parameterized queries in the wasm-sqlite3 API;
+        // string interpolation with single-quote doubling is the correct and only approach.
+        if (key) {
+            db.exec(`PRAGMA key = '${key.replace(/'/g, "''")}';`);
+            logger.debug(MODULE_NAME, `Applied encryption key for ${dbName}`);
+        }
         // WAL mode with OPFS requires exclusive locking mode (SQLite 3.47+)
         // Must be set BEFORE activating WAL mode
         db.exec("PRAGMA locking_mode = exclusive;");

--- a/SqliteWasmBlazor/TypeScript/worker-bridge.ts
+++ b/SqliteWasmBlazor/TypeScript/worker-bridge.ts
@@ -13,6 +13,12 @@ interface IMemoryView {
 
 let worker: Worker | null = null;
 
+// ECDH key-wrapping state — lazily populated on first encrypted open
+let sharedAesKey: CryptoKey | null = null;
+let mainPubKeyRaw: Uint8Array | null = null;
+let pendingKeyExchange: Promise<void> | null = null;
+let resolveKeyExchange: (() => void) | null = null;
+
 // Initialize worker on first import
 (async () => {
     try {
@@ -35,6 +41,37 @@ let worker: Worker | null = null;
                     exports.SqliteWasmBlazor.SqliteWasmWorkerBridge.OnWorkerReady();
                 } catch (error) {
                     console.error('[Worker Bridge] Failed to call OnWorkerReady:', error);
+                }
+                return;
+            }
+
+            // Complete ECDH key exchange when worker sends its public key
+            if (event.data.type === 'workerPublicKey') {
+                try {
+                    const workerPubKey = await crypto.subtle.importKey(
+                        'raw',
+                        event.data.pub,
+                        { name: 'ECDH', namedCurve: 'P-256' },
+                        false,
+                        []
+                    );
+                    const mainKeyPair = await crypto.subtle.generateKey(
+                        { name: 'ECDH', namedCurve: 'P-256' },
+                        true, // must be extractable to export the public key to the worker
+                        ['deriveKey']
+                    );
+                    sharedAesKey = await crypto.subtle.deriveKey(
+                        { name: 'ECDH', public: workerPubKey },
+                        mainKeyPair.privateKey,
+                        { name: 'AES-GCM', length: 256 },
+                        false,
+                        ['encrypt']
+                    );
+                    const rawPub = await crypto.subtle.exportKey('raw', mainKeyPair.publicKey);
+                    mainPubKeyRaw = new Uint8Array(rawPub);
+                    resolveKeyExchange?.();
+                } catch (error) {
+                    console.error('[Worker Bridge] ECDH key exchange failed:', error);
                 }
                 return;
             }
@@ -101,12 +138,42 @@ let worker: Worker | null = null;
 })();
 
 // Called from C# to send request to worker
-export function sendToWorker(messageJson: string): void {
+// Async: if the message carries a SQLCipher key, performs ECDH key exchange (first call only)
+// then encrypts the key with AES-GCM before posting. C# fires and forgets the returned Promise.
+export async function sendToWorker(messageJson: string): Promise<void> {
     if (!worker) {
         throw new Error('Worker not initialized');
     }
 
     const message = JSON.parse(messageJson);
+
+    // Encrypt SQLCipher key if present
+    if (message.data?.key && typeof message.data.key === 'string' && message.data.key.length > 0) {
+        // Lazy key exchange: trigger on first encrypted open
+        if (!sharedAesKey) {
+            if (!pendingKeyExchange) {
+                pendingKeyExchange = new Promise<void>(resolve => {
+                    resolveKeyExchange = resolve;
+                });
+                worker.postMessage({ type: 'initEncryption' });
+            }
+            await pendingKeyExchange;
+        }
+
+        const iv = crypto.getRandomValues(new Uint8Array(12));
+        const ct = await crypto.subtle.encrypt(
+            { name: 'AES-GCM', iv },
+            sharedAesKey!,
+            new TextEncoder().encode(message.data.key)
+        );
+        delete message.data.key;
+        message.data.encryptedKey = {
+            iv: Array.from(iv),
+            ct: Array.from(new Uint8Array(ct)),
+            senderPub: Array.from(mainPubKeyRaw!)
+        };
+    }
+
     worker.postMessage(message);
 }
 

--- a/wasm-build/README.md
+++ b/wasm-build/README.md
@@ -1,0 +1,46 @@
+# SQLCipher WASM Build
+
+Build scripts for a SQLCipher-enabled `sqlite3.wasm` drop-in for `@sqlite.org/sqlite-wasm`.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `prepare-deps.sh` | Clone / verify all external source repos at their pinned versions (step 0) |
+| `build-openssl.sh` | Cross-compile OpenSSL 3.x to WASM (`libcrypto.a`) |
+| `build-sqlcipher.sh` | Generate SQLCipher amalgamation (`sqlite3.c` + `sqlite3.h`) |
+| `patch-gnumakefile.patch` | Adds `SQLCIPHER_*` variable hooks to SQLite's `ext/wasm/GNUmakefile` |
+| `build-wasm.sh` | Orchestrates the full WASM build |
+
+## Frozen Dependency Versions
+
+| Dependency | Source | Pinned version | Commit |
+|---|---|---|---|
+| SQLite | `github.com/sqlite/sqlite` | `version-3.51.3` | `a5333afb9a` |
+| SQLCipher | `github.com/sqlcipher/sqlcipher` | `v4.14.0` | `778ab890` |
+| OpenSSL | downloaded by `build-openssl.sh` | `3.3.2` | — |
+| Emscripten | install via `emsdk` | `5.x` (min `5.0.4`) | — |
+| `@sqlite.org/sqlite-wasm` npm | npm | `3.51.2-build8` | — |
+
+## Prerequisites
+
+- **Emscripten SDK 5.x** (minimum `5.0.4`) — `~/emsdk` or set `EMSDK_PATH`
+  - Install: `cd ~/emsdk && ./emsdk install 5.0.4 && ./emsdk activate 5.0.4 && source emsdk_env.sh`
+- **SQLite source** — `../../sqlite` or set `SQLITE_SRC` (use `prepare-deps.sh` to clone at the pinned tag)
+- **SQLCipher source** — `../../sqlcipher` or set `SQLCIPHER_SRC` (use `prepare-deps.sh`)
+- Build tools: `make`, `wget`/`curl`, `tar`, `gcc`, `tclsh`, `perl`
+
+## Build Steps
+
+```bash
+cd wasm-build/
+./build-wasm.sh            # debug build — runs all steps automatically
+./build-wasm.sh --release  # release build (emcc -Oz, NDEBUG, extra wasm-opt passes)
+```
+
+`build-wasm.sh` automatically calls `prepare-deps.sh`, `build-openssl.sh`, and
+`build-sqlcipher.sh` in order, skipping any step whose output already exists (idempotent).
+
+Output: `wasm-build/out/sqlite3.wasm`.
+`npm run build` automatically uses this file when present instead of the npm-packaged WASM.
+

--- a/wasm-build/build-openssl.sh
+++ b/wasm-build/build-openssl.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Build OpenSSL 3.x as a WASM static library using Emscripten.
+# Output: $OUT_DIR/openssl/{lib/libcrypto.a, include/openssl/...}
+#
+# Usage:
+#   ./build-openssl.sh            # skip if already built
+#   ./build-openssl.sh --force    # rebuild from scratch
+#
+# Prerequisites: emcc (or EMSDK_PATH), wget/curl, tar, make, perl
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT_DIR="${SCRIPT_DIR}/out/openssl"
+OPENSSL_VERSION="${OPENSSL_VERSION:-3.3.2}"
+OPENSSL_SRC_DIR="${SCRIPT_DIR}/src/openssl-${OPENSSL_VERSION}"
+OPENSSL_TARBALL="${SCRIPT_DIR}/src/openssl-${OPENSSL_VERSION}.tar.gz"
+OPENSSL_URL="https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz"
+JOBS="${JOBS:-$(nproc 2>/dev/null || echo 4)}"
+
+# --- parse args ---
+FORCE=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --force) FORCE=1; shift ;;
+        *) echo "Unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+# Activate Emscripten if not in PATH
+if ! command -v emcc &>/dev/null; then
+    EMSDK_PATH="${EMSDK_PATH:-${HOME}/emsdk}"
+    if [[ -f "${EMSDK_PATH}/emsdk_env.sh" ]]; then
+        # shellcheck disable=SC1091
+        source "${EMSDK_PATH}/emsdk_env.sh" >/dev/null 2>&1
+    else
+        echo "ERROR: emcc not found. Install Emscripten SDK or set EMSDK_PATH." >&2
+        exit 1
+    fi
+fi
+
+EMCC_VERSION=$(emcc --version 2>/dev/null | head -1)
+echo "Using emcc: ${EMCC_VERSION}"
+
+# Skip if already built
+if [[ "${FORCE}" -eq 0 && -f "${OUT_DIR}/lib/libcrypto.a" ]]; then
+    echo "OpenSSL WASM already built at ${OUT_DIR}. Use --force to rebuild."
+    exit 0
+fi
+[[ "${FORCE}" -eq 1 ]] && rm -rf "${OUT_DIR}"
+
+mkdir -p "${SCRIPT_DIR}/src"
+
+# Download OpenSSL source if not present
+if [[ ! -d "${OPENSSL_SRC_DIR}" ]]; then
+    if [[ ! -f "${OPENSSL_TARBALL}" ]]; then
+        echo "Downloading OpenSSL ${OPENSSL_VERSION}..."
+        if command -v wget &>/dev/null; then
+            wget -q -O "${OPENSSL_TARBALL}" "${OPENSSL_URL}"
+        else
+            curl -fsSL -o "${OPENSSL_TARBALL}" "${OPENSSL_URL}"
+        fi
+    fi
+    echo "Extracting OpenSSL..."
+    tar -xzf "${OPENSSL_TARBALL}" -C "${SCRIPT_DIR}/src"
+fi
+
+# Build in a separate directory to avoid polluting the source tree
+BUILD_DIR="${SCRIPT_DIR}/src/openssl-${OPENSSL_VERSION}-wasm-build"
+rm -rf "${BUILD_DIR}"
+cp -r "${OPENSSL_SRC_DIR}" "${BUILD_DIR}"
+
+mkdir -p "${OUT_DIR}"
+
+cd "${BUILD_DIR}"
+
+echo "Configuring OpenSSL for WebAssembly..."
+# linux-generic32: closest WASM target; emcc passed directly to avoid emconfigure path issues.
+# Kept: AES-256-CBC, HMAC+PBKDF2 (SHA1/256/512), RAND, OBJ/EVP core, ERR stubs.
+# Disabled: TLS stack, all asymmetric crypto, unused ciphers/hashes/KDFs, WASM-incompatible
+# features (threads, asm, shared, stdio, secure-memory, atexit, rdrand).
+# OPENSSL_SMALL_FOOTPRINT: smaller AES tables; -ffunction/data-sections: dead-code stripping.
+    ./Configure linux-generic32 \
+    no-asm \
+    no-threads \
+    no-shared \
+    no-dso \
+    no-module \
+    no-makedepend \
+    no-tests \
+    no-ssl3 \
+    no-tls \
+    no-dtls \
+    no-quic \
+    no-hw \
+    no-engine \
+    no-ec \
+    no-dh \
+    no-dsa \
+    no-async \
+    no-sock \
+    no-dgram \
+    no-autoload-config \
+    no-atexit \
+    no-cmp \
+    no-http \
+    no-rfc3779 \
+    no-multiblock \
+    no-srtp \
+    no-psk \
+    no-nextprotoneg \
+    no-sctp \
+    no-ktls \
+    no-ssl-trace \
+    no-siv \
+    no-deprecated \
+    no-err \
+    no-autoerrinit \
+    no-filenames \
+    no-stdio \
+    no-ui-console \
+    no-bf \
+    no-cast \
+    no-des \
+    no-rc2 \
+    no-rc4 \
+    no-rc5 \
+    no-idea \
+    no-camellia \
+    no-seed \
+    no-aria \
+    no-chacha \
+    no-poly1305 \
+    no-ocb \
+    no-sm2 \
+    no-sm3 \
+    no-sm4 \
+    no-cmac \
+    no-md4 \
+    no-mdc2 \
+    no-whirlpool \
+    no-rmd160 \
+    no-blake2 \
+    no-siphash \
+    no-scrypt \
+    no-argon2 \
+    no-rdrand \
+    no-secure-memory \
+    no-trace \
+    no-legacy \
+    no-srp \
+    no-comp \
+    no-gost \
+    no-ocsp \
+    no-cms \
+    no-ts \
+    no-ct \
+    --prefix="${OUT_DIR}" \
+    CC=emcc \
+    CXX=em++ \
+    AR=emar \
+    RANLIB=emranlib \
+    CFLAGS="-Oz -ffunction-sections -fdata-sections -DOPENSSL_SMALL_FOOTPRINT"
+
+echo "Building libcrypto..."
+make -j"${JOBS}" build_libs 2>&1
+
+echo "Installing headers and library..."
+mkdir -p "${OUT_DIR}/include"
+cp -r include/openssl "${OUT_DIR}/include/"
+# Copy build-generated headers
+if [[ -f "include/openssl/opensslconf.h" ]]; then
+    cp "include/openssl/opensslconf.h" "${OUT_DIR}/include/openssl/"
+fi
+if [[ -f "include/openssl/configuration.h" ]]; then
+    cp "include/openssl/configuration.h" "${OUT_DIR}/include/openssl/"
+fi
+
+mkdir -p "${OUT_DIR}/lib"
+if [[ -f "libcrypto.a" ]]; then
+    cp libcrypto.a "${OUT_DIR}/lib/"
+elif [[ -f "libcrypto_static.a" ]]; then
+    cp libcrypto_static.a "${OUT_DIR}/lib/libcrypto.a"
+else
+    emmake make install_dev DESTDIR="" 2>&1
+fi
+
+if [[ -f "${OUT_DIR}/lib/libcrypto.a" ]]; then
+    SIZE=$(du -h "${OUT_DIR}/lib/libcrypto.a" | cut -f1)
+    echo ""
+    echo "✓ OpenSSL WASM build complete!"
+    echo "  Library: ${OUT_DIR}/lib/libcrypto.a  (${SIZE})"
+    echo "  Headers: ${OUT_DIR}/include/openssl/"
+else
+    echo "ERROR: libcrypto.a not found after build." >&2
+    exit 1
+fi

--- a/wasm-build/build-sqlcipher.sh
+++ b/wasm-build/build-sqlcipher.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Generate the SQLCipher amalgamation (sqlite3.c + sqlite3.h) from the
+# SQLCipher source tree at ../sqlcipher (or SQLCIPHER_SRC).
+# Output: $SCRIPT_DIR/out/sqlcipher.c and $SCRIPT_DIR/out/sqlcipher.h
+#
+# Uses the HOST compiler (not emcc); the resulting sqlite3.c bakes in
+# SQLCipher crypto under #ifdef SQLITE_HAS_CODEC.
+#
+# Prerequisites: gcc/clang, make, tclsh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SQLCIPHER_SRC="${SQLCIPHER_SRC:-${SCRIPT_DIR}/../../sqlcipher}"
+OUT_DIR="${SCRIPT_DIR}/out"
+JOBS="${JOBS:-$(nproc 2>/dev/null || echo 4)}"
+
+if [[ ! -d "${SQLCIPHER_SRC}" ]]; then
+    echo "ERROR: SQLCipher source directory not found: ${SQLCIPHER_SRC}" >&2
+    echo "  Clone it with: git clone https://github.com/sqlcipher/sqlcipher.git ../../sqlcipher" >&2
+    exit 1
+fi
+
+# Skip if already built
+if [[ -f "${OUT_DIR}/sqlcipher.c" && -f "${OUT_DIR}/sqlcipher.h" ]]; then
+    echo "SQLCipher amalgamation already at ${OUT_DIR}. Delete to rebuild."
+    exit 0
+fi
+
+mkdir -p "${OUT_DIR}"
+
+# Build in a clean copy to avoid polluting the source tree
+BUILD_DIR="${SCRIPT_DIR}/src/sqlcipher-build"
+rm -rf "${BUILD_DIR}"
+mkdir -p "${SCRIPT_DIR}/src"
+cp -r "${SQLCIPHER_SRC}" "${BUILD_DIR}"
+
+cd "${BUILD_DIR}"
+
+echo "Configuring SQLCipher (host compiler, amalgamation only)..."
+# --with-tempstore=yes: SQLITE_TEMP_STORE=2 in the amalgamation
+# -DSQLITE_HAS_CODEC: includes SQLCipher codec sources
+./configure \
+    --with-tempstore=yes \
+    CFLAGS="-DSQLITE_HAS_CODEC" \
+    2>&1
+
+echo "Generating SQLCipher amalgamation..."
+make -j"${JOBS}" sqlite3.c 2>&1
+
+# Verify
+if [[ ! -f "sqlite3.c" || ! -f "sqlite3.h" ]]; then
+    echo "ERROR: sqlite3.c / sqlite3.h not generated." >&2
+    exit 1
+fi
+
+cp sqlite3.c "${OUT_DIR}/sqlcipher.c"
+cp sqlite3.h "${OUT_DIR}/sqlcipher.h"
+# sqlite3.h must sit next to sqlcipher.c (GNUmakefile derives it by path)
+cp sqlite3.h "${OUT_DIR}/sqlite3.h"
+
+# Guard .fini_array usage for Emscripten (cleanup handled via SQLITE_EXTRA_SHUTDOWN).
+python3 - "${OUT_DIR}/sqlcipher.c" << 'PYEOF'
+import sys
+path = sys.argv[1]
+with open(path) as f:
+    src = f.read()
+old = ('#else\nstatic void (*const sqlcipher_fini_func)(void)'
+       ' __attribute__((used, section(".fini_array")))'
+       ' = sqlcipher_fini;\n#endif')
+new = ('#elif !defined(__EMSCRIPTEN__)\nstatic void (*const sqlcipher_fini_func)(void)'
+       ' __attribute__((used, section(".fini_array")))'
+       ' = sqlcipher_fini;\n#endif')
+if old not in src:
+    print("WARNING: .fini_array guard pattern not found in sqlcipher.c — skipping patch", flush=True)
+else:
+    with open(path, 'w') as f:
+        f.write(src.replace(old, new, 1))
+    print("  Applied .fini_array -> __EMSCRIPTEN__ guard", flush=True)
+PYEOF
+
+C_LINES=$(wc -l < "${OUT_DIR}/sqlcipher.c")
+echo ""
+echo "✓ SQLCipher amalgamation complete!"
+echo "  ${OUT_DIR}/sqlcipher.c  (${C_LINES} lines)"
+echo "  ${OUT_DIR}/sqlcipher.h  (SQLCipher-modified API)"
+echo "  ${OUT_DIR}/sqlite3.h    (alias — needed by SQLite GNUmakefile)"

--- a/wasm-build/build-wasm.sh
+++ b/wasm-build/build-wasm.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# Build sqlite3.wasm with SQLCipher encryption support.
+#
+# This is the one-stop build script: it automatically runs prepare-deps.sh,
+# build-openssl.sh, and build-sqlcipher.sh as needed (all idempotent — safe
+# to call multiple times; each step is skipped when its output already exists).
+#
+# Output: wasm-build/out/sqlite3.wasm (drop-in for @sqlite.org/sqlite-wasm)
+#
+# Usage:
+#   ./build-wasm.sh            # debug build (runs all steps automatically)
+#   ./build-wasm.sh --release  # emcc -Oz + wasm-opt -Oz
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT_DIR="${SCRIPT_DIR}/out"
+_SQLITE_DEFAULT="$(cd "${SCRIPT_DIR}/../../sqlite" 2>/dev/null && pwd || echo "${SCRIPT_DIR}/../../sqlite")"
+SQLITE_SRC="${SQLITE_SRC:-${_SQLITE_DEFAULT}}"
+# Build in sqlite/ext/wasm-sqlcipher so dir.top=../.. resolves to the SQLite root.
+BUILD_DIR="${SQLITE_SRC}/ext/wasm-sqlcipher"
+JOBS="${JOBS:-$(nproc 2>/dev/null || echo 4)}"
+OPT=""  # set to -Oz by --release
+
+# Use a modern Emscripten (5.x) to match the feature set used by @sqlite.org/sqlite-wasm.
+# The JS glue patch (patches/@sqlite.org+sqlite-wasm+*.patch) adds the 3 extra imports that
+# 5.x WASM requires (_abort_js, __syscall_renameat, __syscall_getdents64) so any 5.x version
+# works. The minimum verified version is 5.0.4 (the Docker latest at npm package publish time).
+# NOTE: 3.1.56 in the CI workflows is only for the native stub, not this WASM build.
+EMCC_REQUIRED_VERSION="5.0.4"
+EMCC_REQUIRED_MAJOR="5"
+NPM_WASM_VERSION="3.51.2-build8"
+#
+# COMPATIBILITY NOTE: the @sqlite.org/sqlite-wasm npm package (3.51.2-build8) was built from
+# SQLite's "wasm-post-3.51" dev branch (SQLite ~3.52), which extended sqlite3_kvvfs_methods
+# with WASM-specific fields (pVfs, pIoDb, pIoJrnl, nBufferSize).  The SQLite mainline release
+# used here (3.51.3) does NOT have those extra fields.  The JS glue patch handles this via an
+# early-return guard in the kvvfs bootstrap initializer, so the C-only kvvfs implementation
+# stays active while OPFS SAHPool VFS (the VFS actually used by this project) works normally.
+
+# --- parse args ---
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --release) OPT="-Oz"; shift ;;
+        *) echo "Unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+# --- activate Emscripten ---
+if ! command -v emcc &>/dev/null; then
+    EMSDK_PATH="${EMSDK_PATH:-${HOME}/emsdk}"
+    if [[ -f "${EMSDK_PATH}/emsdk_env.sh" ]]; then
+        # shellcheck disable=SC1091
+        source "${EMSDK_PATH}/emsdk_env.sh" >/dev/null 2>&1
+    else
+        echo "ERROR: emcc not found. Install Emscripten SDK or set EMSDK_PATH." >&2
+        exit 1
+    fi
+fi
+
+# --- verify Emscripten version ---
+EMCC_ACTUAL_VERSION="$(emcc --version 2>/dev/null | head -1 | grep -oP '\d+\.\d+\.\d+' | head -1)"
+EMCC_ACTUAL_MAJOR="$(echo "${EMCC_ACTUAL_VERSION}" | cut -d. -f1)"
+if [[ "${EMCC_ACTUAL_MAJOR}" != "${EMCC_REQUIRED_MAJOR}" ]]; then
+    echo "ERROR: emcc ${EMCC_ACTUAL_VERSION} found, but Emscripten ${EMCC_REQUIRED_MAJOR}.x is required." >&2
+    echo "       The WASM binary must be compiled with emcc ${EMCC_REQUIRED_MAJOR}.x; the JS glue patch" >&2
+    echo "       (patches/@sqlite.org+sqlite-wasm+*.patch) covers the import differences within that" >&2
+    echo "       major version. Minimum verified: ${EMCC_REQUIRED_VERSION}." >&2
+    echo "" >&2
+    echo "Fix:" >&2
+    echo "  cd \${EMSDK_PATH:-\$HOME/emsdk}" >&2
+    echo "  ./emsdk install ${EMCC_REQUIRED_VERSION}" >&2
+    echo "  ./emsdk activate ${EMCC_REQUIRED_VERSION}" >&2
+    echo "  source emsdk_env.sh" >&2
+    echo "  # then re-run this script" >&2
+    exit 1
+fi
+
+# --- step 0: ensure source repos are at the pinned versions ---
+echo "=== Step 0: Preparing source dependencies ==="
+"${SCRIPT_DIR}/prepare-deps.sh"
+echo ""
+
+# --- step 1: OpenSSL WASM static lib (idempotent: skipped if already built) ---
+OPENSSL_LIB="${OUT_DIR}/openssl/lib/libcrypto.a"
+if [[ ! -f "${OPENSSL_LIB}" ]]; then
+    echo "=== Step 1: Building OpenSSL for WASM ==="
+    "${SCRIPT_DIR}/build-openssl.sh"
+    echo ""
+else
+    echo "=== Step 1: OpenSSL already built — skipping ==="
+    echo ""
+fi
+
+# --- step 2: SQLCipher amalgamation (idempotent: skipped if already built) ---
+SQLCIPHER_C="${OUT_DIR}/sqlcipher.c"
+SQLCIPHER_H="${OUT_DIR}/sqlcipher.h"
+if [[ ! -f "${SQLCIPHER_C}" || ! -f "${SQLCIPHER_H}" ]]; then
+    echo "=== Step 2: Generating SQLCipher amalgamation ==="
+    "${SCRIPT_DIR}/build-sqlcipher.sh"
+    echo ""
+else
+    echo "=== Step 2: SQLCipher amalgamation already generated — skipping ==="
+    echo ""
+fi
+
+OPENSSL_INC="${OUT_DIR}/openssl/include"
+
+if [[ ! -d "${SQLITE_SRC}/ext/wasm" ]]; then
+    echo "ERROR: SQLite source directory not found: ${SQLITE_SRC}" >&2
+    echo "  Run ./prepare-deps.sh first, or set SQLITE_SRC." >&2
+    exit 1
+fi
+
+echo "=== Step 3: Building SQLCipher WASM ==="
+echo "  emcc:           $(emcc --version 2>/dev/null | head -1)"
+echo "  SQLCipher:      ${SQLCIPHER_C}"
+echo "  OpenSSL lib:    ${OPENSSL_LIB}"
+echo "  SQLite src:     ${SQLITE_SRC}"
+echo ""
+
+# --- bootstrap: ensure sqlite3.c + Makefile exist in the SQLite source root ---
+# Utility tools in GNUmakefile need $(dir.top)/sqlite3.c compiled with the HOST compiler.
+if [[ ! -f "${SQLITE_SRC}/sqlite3.c" || ! -f "${SQLITE_SRC}/Makefile" ]]; then
+    echo "--- Bootstrapping SQLite source tree (configure + sqlite3.c) ---"
+    pushd "${SQLITE_SRC}" > /dev/null
+    ./configure --disable-tcl 2>&1
+    make sqlite3.c sqlite3.h 2>&1
+    popd > /dev/null
+    echo "--- Bootstrap complete ---"
+    echo ""
+fi
+
+# --- set up a clean working copy of ext/wasm inside the SQLite source tree ---
+# Must be at ext/wasm-sqlcipher/ so dir.top=../.. still resolves to the SQLite root.
+rm -rf "${BUILD_DIR}"
+cp -r "${SQLITE_SRC}/ext/wasm" "${BUILD_DIR}"
+# Ensure all files are owner-writable before patching.
+chmod -R u+w "${BUILD_DIR}"
+
+# Apply the patch to add SQLCIPHER_EXTRA_CFLAGS / SQLCIPHER_LINK_FLAGS / SQLCIPHER_INCLUDE_FLAGS
+cd "${BUILD_DIR}"
+patch -p3 < "${SCRIPT_DIR}/patch-gnumakefile.patch"
+
+# Ensure sqlite3_next_stmt is exported. It was added to the wasm-post-3.51 dev branch
+# in Nov 2025 but has not yet merged to the SQLite trunk. The npm package (@sqlite.org/sqlite-wasm)
+# was built from a source tree that includes it, so our WASM must export it too.
+EXPORTS_CORE="${BUILD_DIR}/api/EXPORTED_FUNCTIONS.sqlite3-core"
+if [[ -f "${EXPORTS_CORE}" ]] && ! grep -q "_sqlite3_next_stmt" "${EXPORTS_CORE}"; then
+    echo "_sqlite3_next_stmt" >> "${EXPORTS_CORE}"
+fi
+
+# Patch sqlcipher.c: remove the .fini_array section attribute added in SQLCipher 4.9.0.
+# `.fini_array` is unsupported in WASM and can crash the LLVM wasm backend during cleanup.
+# See: https://github.com/7mind/sqlcipher-wasm/blob/main/lib.sh (patch_amalgamation)
+# We patch a local copy so the source artifact at ${SQLCIPHER_C} is not modified.
+SQLCIPHER_PATCHED_C="${OUT_DIR}/sqlcipher-patched.c"
+cp "${SQLCIPHER_C}" "${SQLCIPHER_PATCHED_C}"
+sed -i 's/__attribute__((used, section(".fini_array")))//' "${SQLCIPHER_PATCHED_C}"
+# Restore original mtime so GNUmakefile's freshness check against sqlite3.h still passes.
+touch --reference="${SQLCIPHER_C}" "${SQLCIPHER_PATCHED_C}"
+
+# --- create config.make (normally generated by the configure script) ---
+EMCC_BIN="$(command -v emcc)"
+BASH_BIN="$(command -v bash)"
+# Prefer wabt wasm-strip; fall back to llvm-strip from emsdk.
+WASM_STRIP_BIN="$(command -v wasm-strip 2>/dev/null || echo '')"
+if [[ -z "${WASM_STRIP_BIN}" ]]; then
+    _EMSDK_PATH="${EMSDK_PATH:-${HOME}/emsdk}"
+    [[ -x "${_EMSDK_PATH}/upstream/bin/llvm-strip" ]] && WASM_STRIP_BIN="${_EMSDK_PATH}/upstream/bin/llvm-strip"
+fi
+# wasm-opt from Binaryen (bundled with emsdk).
+WASM_OPT_BIN="$(command -v wasm-opt 2>/dev/null || echo '')"
+if [[ -z "${WASM_OPT_BIN}" ]]; then
+    _EMSDK_PATH="${EMSDK_PATH:-${HOME}/emsdk}"
+    [[ -x "${_EMSDK_PATH}/upstream/bin/wasm-opt" ]] && WASM_OPT_BIN="${_EMSDK_PATH}/upstream/bin/wasm-opt"
+fi
+
+cat > "${BUILD_DIR}/config.make" <<EOF
+bin.bash     = ${BASH_BIN}
+bin.emcc     = ${EMCC_BIN}
+bin.wasm-strip = ${WASM_STRIP_BIN:-}
+bin.wasm-opt = ${WASM_OPT_BIN:-}
+SHELL        = ${BASH_BIN}
+SHELL_OPT    = -DSQLITE_THREADSAFE=0
+SHELL_DEP    = \$(dir.top)/sqlite3.c
+EOF
+
+# --- build ---
+# SQLCipher / crypto CFLAGS
+SQLCIPHER_CFLAGS="-DSQLITE_HAS_CODEC -DSQLCIPHER_CRYPTO_OPENSSL"
+SQLCIPHER_CFLAGS+=" -I${OPENSSL_INC}"
+SQLCIPHER_CFLAGS+=" -USQLITE_THREADSAFE -DSQLITE_THREADSAFE=1"
+SQLCIPHER_CFLAGS+=" -DSQLITE_EXTRA_INIT=sqlcipher_extra_init -DSQLITE_EXTRA_SHUTDOWN=sqlcipher_extra_shutdown"
+# Release: strip debug assertions.
+[[ -n "${OPT}" ]] && SQLCIPHER_CFLAGS+=" -DNDEBUG -DSQLITE_NDEBUG"
+
+echo "Running GNUmakefile..."
+make -C "${BUILD_DIR}" \
+    "sqlite3.c=${SQLCIPHER_PATCHED_C}" \
+    "SQLCIPHER_EXTRA_CFLAGS=${SQLCIPHER_CFLAGS}" \
+    "SQLCIPHER_LINK_FLAGS=${OPENSSL_LIB}" \
+    ${OPT:+"emcc_opt=${OPT}"} \
+    -j"${JOBS}" \
+    jswasm/sqlite3.wasm \
+    2>&1
+
+WASM_OUT="${BUILD_DIR}/jswasm/sqlite3.wasm"
+if [[ ! -f "${WASM_OUT}" ]]; then
+    echo "ERROR: jswasm/sqlite3.wasm not produced." >&2
+    exit 1
+fi
+
+# --- copy output ---
+cp "${WASM_OUT}" "${OUT_DIR}/sqlite3.wasm"
+
+# Fallback strip when wasm-strip was not found during config.make generation
+if [[ -z "${WASM_STRIP_BIN}" && -n "$(command -v llvm-strip 2>/dev/null)" ]]; then
+    llvm-strip --strip-debug "${OUT_DIR}/sqlite3.wasm"
+elif [[ -z "${WASM_STRIP_BIN}" ]]; then
+    echo "  (wasm-strip/llvm-strip not found — debug sections retained; install wabt or emsdk)"
+fi
+
+# --- additional wasm-opt pass ---
+if [[ -n "${WASM_OPT_BIN}" ]]; then
+    BEFORE=$(wc -c < "${OUT_DIR}/sqlite3.wasm")
+    OPT_PASSES="-Oz --enable-bulk-memory --all-features --post-emscripten --strip-debug --local-cse"
+    OPT_PASSES+=' --vacuum --reorder-functions --reorder-locals'
+    # Release: extra dead-code, dedup, and instruction-level peephole passes
+    [[ -n "${OPT}" ]] && OPT_PASSES+=' --code-folding --duplicate-function-elimination --strip-producers --optimize-instructions'
+    # shellcheck disable=SC2086
+    "${WASM_OPT_BIN}" $OPT_PASSES \
+        "${OUT_DIR}/sqlite3.wasm" -o "${OUT_DIR}/sqlite3.wasm"
+    AFTER=$(wc -c < "${OUT_DIR}/sqlite3.wasm")
+    echo "  wasm-opt: $(( BEFORE / 1024 ))K → $(( AFTER / 1024 ))K"
+fi
+BYTES_CIPHER=$(wc -c < "${OUT_DIR}/sqlite3.wasm")
+echo ""
+echo "✓ SQLCipher WASM build complete!"
+echo "  Output: ${OUT_DIR}/sqlite3.wasm  ($(( BYTES_CIPHER / 1024 )) KB)"
+
+# --- size comparison vs standard @sqlite.org/sqlite-wasm ---
+STOCK_WASM="${SCRIPT_DIR}/../SqliteWasmBlazor/TypeScript/node_modules/@sqlite.org/sqlite-wasm/dist/sqlite3.wasm"
+echo ""
+echo "Size comparison:"
+if [[ -f "${STOCK_WASM}" ]]; then
+    BYTES_STOCK=$(wc -c < "${STOCK_WASM}")
+    echo "  Standard sqlite3.wasm : $(( BYTES_STOCK  / 1024 )) KB"
+    echo "  SQLCipher sqlite3.wasm: $(( BYTES_CIPHER / 1024 )) KB  (+$(( (BYTES_CIPHER - BYTES_STOCK) / 1024 )) KB)"
+else
+    echo "  SQLCipher sqlite3.wasm: $(( BYTES_CIPHER / 1024 )) KB"
+    echo "  (standard wasm not found at ${STOCK_WASM} — run 'npm install' to enable comparison)"
+fi
+
+echo ""
+echo "  Run 'npm run build' from SqliteWasmBlazor/TypeScript/ to pick it up."

--- a/wasm-build/patch-gnumakefile.patch
+++ b/wasm-build/patch-gnumakefile.patch
@@ -1,0 +1,30 @@
+--- a/ext/wasm/GNUmakefile
++++ b/ext/wasm/GNUmakefile
+@@ -404,7 +404,8 @@
+   -DSQLITE_OMIT_DEPRECATED \
+   -DSQLITE_OMIT_UTF16 \
+   -DSQLITE_OMIT_LOAD_EXTENSION \
+-  -DSQLITE_OMIT_SHARED_CACHE
++  -DSQLITE_OMIT_SHARED_CACHE \
++  $(SQLCIPHER_EXTRA_CFLAGS)
+ # ^^^ These particular OMITs are hard-coded in sqlite3-wasm.c and
+ # removing them from this list will serve only to break the speedtest1
+ # builds.
+@@ -430,7 +431,8 @@
+ ifeq (0,$(wasm-bare-bones))
+   # The so-called canonical build is full-featured:
+   SQLITE_OPT = \
+     $(SQLITE_OPT.common) \
+-    $(SQLITE_OPT.full-featured)
++    $(SQLITE_OPT.full-featured) \
++    $(SQLCIPHER_FEATURE_FLAGS)
+ else
+   # The so-called bare-bones build is exactly that:
+@@ -801,6 +803,7 @@
+ # Re. undefined symbol handling, see: https://lld.llvm.org/WebAssembly.html
+ emcc.jsflags += -sERROR_ON_UNDEFINED_SYMBOLS=1
+ emcc.jsflags += -sLLD_REPORT_UNDEFINED
++emcc.jsflags += $(SQLCIPHER_LINK_FLAGS)
+ #emcc.jsflags += --allow-undefined
+ #emcc.jsflags += --import-undefined
+ #emcc.jsflags += --unresolved-symbols=import-dynamic --experimental-pic

--- a/wasm-build/prepare-deps.sh
+++ b/wasm-build/prepare-deps.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# prepare-deps.sh — Clone and pin all external source dependencies needed for
+# the SQLCipher WASM build.  Run this once before the build steps.
+#
+# Frozen dependency versions (current known-good state):
+#   SQLite    github.com/sqlite/sqlite         tag  version-3.51.3  (a5333afb9a)
+#   SQLCipher github.com/sqlcipher/sqlcipher   tag  v4.14.0         (778ab890)
+#   OpenSSL   3.3.2  (downloaded automatically by build-openssl.sh)
+#   Emscripten SDK 5.x — minimum 5.0.4  (install separately via emsdk)
+#   @sqlite.org/sqlite-wasm npm package   3.51.2-build8  (declared in package.json)
+#
+# Usage:
+#   cd wasm-build/
+#   ./prepare-deps.sh            # clone if absent, verify if present
+#   ./prepare-deps.sh --update   # force checkout of pinned versions even if present
+#
+# After this script succeeds, run the build steps:
+#   ./build-openssl.sh
+#   ./build-sqlcipher.sh
+#   ./build-wasm.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEPS_ROOT="$(cd "${REPO_ROOT}/.." && pwd)"
+
+# --- pinned versions ---
+SQLITE_REPO="https://github.com/sqlite/sqlite"
+SQLITE_TAG="version-3.51.3"
+SQLITE_COMMIT="a5333afb9a"
+SQLITE_DIR="${SQLITE_DIR:-${DEPS_ROOT}/sqlite}"
+
+SQLCIPHER_REPO="https://github.com/sqlcipher/sqlcipher"
+SQLCIPHER_TAG="v4.14.0"
+SQLCIPHER_COMMIT="778ab890"
+SQLCIPHER_DIR="${SQLCIPHER_DIR:-${DEPS_ROOT}/sqlcipher}"
+
+# --- parse args ---
+UPDATE=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --update) UPDATE=1; shift ;;
+        *) echo "Unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+# Helper: print a coloured status line
+ok()   { echo "  [OK]   $*"; }
+warn() { echo "  [WARN] $*"; }
+info() { echo "         $*"; }
+
+# Helper: clone a repo and check out a pinned tag, or verify/update an existing clone.
+# Usage: setup_repo <display_name> <dir> <repo_url> <tag> <commit_prefix>
+setup_repo() {
+    local name="$1" dir="$2" repo="$3" tag="$4" commit="$5"
+
+    echo ""
+    echo "--- ${name} ---"
+
+    if [[ ! -d "${dir}/.git" ]]; then
+        echo "  Cloning ${repo} ..."
+        git clone --depth 1 --branch "${tag}" "${repo}" "${dir}"
+        ok "Cloned at tag ${tag}"
+        return
+    fi
+
+    # Repo exists — check current state
+    local current_commit
+    current_commit="$(git -C "${dir}" rev-parse --short HEAD 2>/dev/null || echo 'unknown')"
+    local current_tag
+    current_tag="$(git -C "${dir}" describe --tags --exact-match HEAD 2>/dev/null || echo '')"
+
+    if [[ "${current_commit}" == "${commit}"* || "${current_tag}" == "${tag}" ]]; then
+        ok "Already at ${tag} (${current_commit})"
+        return
+    fi
+
+    if [[ "${UPDATE}" -eq 1 ]]; then
+        echo "  Fetching and checking out ${tag} ..."
+        git -C "${dir}" fetch --depth 1 origin "refs/tags/${tag}:refs/tags/${tag}" 2>/dev/null \
+            || git -C "${dir}" fetch origin 2>/dev/null
+        git -C "${dir}" checkout "${tag}"
+        ok "Checked out ${tag}"
+    else
+        warn "Repo at ${dir} is NOT at the pinned tag ${tag}."
+        info "Current: ${current_commit}${current_tag:+ (${current_tag})}"
+        info "Run with --update to checkout ${tag}, or set the *_DIR env var to a different path."
+    fi
+}
+
+echo "=== Preparing dependencies for SQLCipher WASM build ==="
+echo ""
+echo "  Deps root : ${DEPS_ROOT}"
+echo "  Pinned versions:"
+echo "    SQLite    ${SQLITE_TAG}     (${SQLITE_COMMIT})  → ${SQLITE_DIR}"
+echo "    SQLCipher ${SQLCIPHER_TAG}  (${SQLCIPHER_COMMIT}) → ${SQLCIPHER_DIR}"
+echo "    OpenSSL   3.3.2  (downloaded by build-openssl.sh)"
+echo "    Emscripten 5.x (min 5.0.4, install separately via emsdk)"
+echo "    @sqlite.org/sqlite-wasm 3.51.2-build8 (npm — see package.json)"
+
+setup_repo "SQLite" "${SQLITE_DIR}" "${SQLITE_REPO}" "${SQLITE_TAG}" "${SQLITE_COMMIT}"
+setup_repo "SQLCipher" "${SQLCIPHER_DIR}" "${SQLCIPHER_REPO}" "${SQLCIPHER_TAG}" "${SQLCIPHER_COMMIT}"
+
+echo ""
+echo "=== Dependency check complete ==="
+echo ""
+echo "Next steps:"
+echo "  cd ${SCRIPT_DIR}"
+echo "  ./build-openssl.sh"
+echo "  ./build-sqlcipher.sh"
+echo "  ./build-wasm.sh"


### PR DESCRIPTION
Hey @b-straub, I forked your repository because I use it for a hobby project of mine.
I then had the idea to add encryption and it worked pretty well.

So here is my PR with the necessary changes to add encryption (SQLCipher WASM), if you want this in your nuget.
Judging from the **Enterprise-Ready** header, I thought this addition might fit.
Open to feedback/improvement/questions/whatever.

# SQLCipher Encryption + Key Security Hardening

## Three valid shipping configurations — all backward compatible

This PR is purely additive. The nuget can ship in any of three ways without breaking existing users:

| Configuration | WASM binary | `Password=` | Encrypted DB |
|---|---|---|---|
| **Original** (unchanged) | npm `sqlite3.wasm` (~836 KB) | ignored | ✗ |
| **SQLCipher binary, no encryption** | custom `sqlite3.wasm` (~1.4 MB) | no password supplied | ✗ |
| **SQLCipher binary + encryption** | custom `sqlite3.wasm` (~1.4 MB) | applied as `PRAGMA key` | ✓ |

Omitting `Password=` from the connection string is always safe under any configuration — `PRAGMA key` is never sent and the database behaves identically to a plain SQLite database.

---

## Downside: custom WASM binary

First downside: The SQLCipher-enabled `sqlite3.wasm` is ~540 KB larger than the standard npm binary (~836 KB → ~1.4 MB). The `wasm-build/` directory has all the scripts to reproduce it.

If this is too big, the nuget could be shipped in two different configurations.

- **`SqliteWasmBlazor`** — standard binary, no encryption (current package, unchanged size)
- **`SqliteWasmBlazor.Cipher`** — SQLCipher binary, full encryption support (+~540 KB)

Both packages share the same C# and TypeScript code from this PR; only the bundled `.wasm` differs.

Second downside: The SQLCipher-enabled `sqlite3.wasm` is built manually, if you want updates, you will have to build (and possibly debug) it for the new version again.

---

## What changed

### SQLCipher support

Databases in OPFS can now be encrypted at rest via `Password=` in the connection string. Without this, any script with OPFS access or a compromised storage layer can read the raw `.db` file.

### ECDH key wrapping

The worker communicates via `postMessage`, which is fully visible in DevTools. Sending the password in plaintext means any developer — or code with access to the page — can trivially read it. The key is now encrypted with an ephemeral ECDH-P256 + AES-GCM session before it crosses the main-thread → worker boundary.

Lazy: zero overhead for non-encrypted databases. The key exchange only happens on the first encrypted `open`.

### CSP

Blocks injected scripts from intercepting the key before or after encryption. `worker-src 'self'` prevents loading worker code from external origins — the browser-level equivalent of SRI for workers. This closes the most realistic attack vector against the ECDH scheme (same-origin code injection via XSS).

The `data:text/javascript,...` JSImport previously used to read `baseHref` violates `script-src 'self'` and had to be removed as a prerequisite.

### Bug fix: `UseSqliteWasm<TContext>`

Missing generic overloads caused `CS1503` when calling `.UseSqliteWasm().Options` on a `DbContextOptionsBuilder<TContext>` — the non-generic overload silently discarded the type parameter, breaking `new TodoDbContext(options)`.

---

## Tests

72/72 passing. 15 new tests:

- `ConnectionStringParsingTests` — 12 unit cases for `ParsePassword` (`null`, empty, no password, `=` in value, case-insensitive key, whitespace trim, empty/whitespace-only value, key ordering)
- `Encryption_BasicCRUD` — create+insert, close, reopen, verify record survives round-trip
- `Encryption_SpecialCharsPassword` — single-quote in password escaped correctly before `PRAGMA key`
- `Encryption_WrongPassword` — wrong key throws instead of silently corrupting