### PR TITLE
CSP hardening, remove data:text/javascript, parameterize baseHref

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ builder.Services.AddSqliteWasm();
 var host = builder.Build();
 
 // Initialize SqliteWasm database with automatic migration support
-await host.Services.InitializeSqliteWasmDatabaseAsync<TodoDbContext>();
+// Pass builder.HostEnvironment so sub-path deployments resolve the worker bridge correctly.
+await host.Services.InitializeSqliteWasmDatabaseAsync<TodoDbContext>(builder.HostEnvironment);
 
 await host.RunAsync();
 ```

--- a/SqliteWasmBlazor.AdoNetSample/Program.cs
+++ b/SqliteWasmBlazor.AdoNetSample/Program.cs
@@ -12,6 +12,6 @@ builder.Services.AddScoped(_ => new HttpClient { BaseAddress = new Uri(builder.H
 var host = builder.Build();
 
 // Initialize SqliteWasm for ADO.NET usage (no EF Core needed!)
-await host.Services.InitializeSqliteWasmAsync();
+await host.Services.InitializeSqliteWasmAsync(builder.HostEnvironment);
 
 await host.RunAsync();

--- a/SqliteWasmBlazor.AdoNetSample/README.md
+++ b/SqliteWasmBlazor.AdoNetSample/README.md
@@ -18,8 +18,11 @@ Shows how to initialize SqliteWasm without EF Core:
 
 ```csharp
 // Initialize SqliteWasm for ADO.NET usage (no EF Core needed!)
-await host.Services.InitializeSqliteWasmAsync();
+// Pass HostEnvironment so sub-path deployments (e.g. <base href="/myapp/">) resolve the worker correctly.
+await host.Services.InitializeSqliteWasmAsync(builder.HostEnvironment);
 ```
+
+> **Sub-path deployments:** passing `builder.HostEnvironment` is the recommended approach. The library derives `baseHref` from `HostEnvironment.BaseAddress`, which already reflects the `<base href>` baked in at build time. See [Deploying Under a Sub-path](../docs/advanced-features.md#deploying-under-a-sub-path) for details.
 
 ### Pages/Home.razor
 Complete ADO.NET example with:

--- a/SqliteWasmBlazor.AdoNetSample/wwwroot/index.html
+++ b/SqliteWasmBlazor.AdoNetSample/wwwroot/index.html
@@ -5,6 +5,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SqliteWasmBlazor.AdoNetSample</title>
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'">
     <base href="/" />
     <link rel="preload" id="webassembly" />
     <link rel="stylesheet" href="css/app.css" />

--- a/SqliteWasmBlazor.Components/Interop/FileOperationsInterop.cs
+++ b/SqliteWasmBlazor.Components/Interop/FileOperationsInterop.cs
@@ -23,7 +23,8 @@ public static partial class FileOperationsInterop
     /// Initialize the file operations module
     /// Must be called in Program.cs before WebAssemblyHostBuilder.Build()
     /// </summary>
-    public static async Task InitializeAsync()
+    /// <param name="assetRoot">Static-asset path segment, e.g. "_content/SqliteWasmBlazor.Components/". Override for browser-extension builds.</param>
+    public static async Task InitializeAsync(string assetRoot = "_content/SqliteWasmBlazor.Components/")
     {
         if (!OperatingSystem.IsBrowser())
         {
@@ -34,7 +35,7 @@ public static partial class FileOperationsInterop
         {
             await JSHost.ImportAsync(
                 ModuleName,
-                "../_content/SqliteWasmBlazor.Components/file-operations.js");
+                $"../{assetRoot}file-operations.js");
             Console.WriteLine("FileOperations module loaded successfully");
         }
         catch (Exception ex)

--- a/SqliteWasmBlazor.Demo/Program.cs
+++ b/SqliteWasmBlazor.Demo/Program.cs
@@ -67,7 +67,7 @@ await FileOperationsInterop.InitializeAsync();
 var host = builder.Build();
 
 // Initialize SqliteWasm databases with migration support
-await host.Services.InitializeSqliteWasmDatabaseAsync<TodoDbContext>();
-await host.Services.InitializeSqliteWasmDatabaseAsync<NoteDbContext>();
+await host.Services.InitializeSqliteWasmDatabaseAsync<TodoDbContext>(builder.HostEnvironment);
+await host.Services.InitializeSqliteWasmDatabaseAsync<NoteDbContext>(builder.HostEnvironment);
 
 await host.RunAsync();

--- a/SqliteWasmBlazor.Demo/wwwroot/index.html
+++ b/SqliteWasmBlazor.Demo/wwwroot/index.html
@@ -32,8 +32,8 @@
     </div>
     <script src="_framework/blazor.webassembly.js" crossorigin="anonymous"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js" crossorigin="anonymous"></script>
-    <script>navigator.serviceWorker.register('service-worker.js', { updateViaCache: 'none' });</script>
-    <script src="service-worker-update.js"></script>
+    <!--SW_REGISTER_PLACEHOLDER-->
+    <!--SW_UPDATE_PLACEHOLDER-->
 </body>
 
 </html>

--- a/SqliteWasmBlazor.Demo/wwwroot/index.html
+++ b/SqliteWasmBlazor.Demo/wwwroot/index.html
@@ -5,6 +5,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SqliteWasmBlazor.Demo</title>
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'">
     <base href="/" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" crossorigin="anonymous" />
     <link href="_content/SqliteWasmBlazor.FloatingWindow/floating-window.css" rel="stylesheet" />

--- a/SqliteWasmBlazor.FloatingWindow/Components/FloatingWindow.razor
+++ b/SqliteWasmBlazor.FloatingWindow/Components/FloatingWindow.razor
@@ -1,5 +1,6 @@
 @inject IWindowManager WindowManager
 @inject IJSRuntime JSRuntime
+@inject FloatingWindowOptions FloatingWindowOptions
 
 @if (IsOpen && _state is not null && !_state.IsMinimized)
 {

--- a/SqliteWasmBlazor.FloatingWindow/Components/FloatingWindow.razor.cs
+++ b/SqliteWasmBlazor.FloatingWindow/Components/FloatingWindow.razor.cs
@@ -258,7 +258,7 @@ public partial class FloatingWindow : IAsyncDisposable
         try
         {
             _jsModule = await JSRuntime.InvokeAsync<IJSObjectReference>(
-                "import", "./_content/SqliteWasmBlazor.FloatingWindow/floating-window.js");
+                "import", $"./{FloatingWindowOptions.AssetRoot}floating-window.js");
 
             if (Draggable)
             {

--- a/SqliteWasmBlazor.FloatingWindow/Extensions/ServiceCollectionExtensions.cs
+++ b/SqliteWasmBlazor.FloatingWindow/Extensions/ServiceCollectionExtensions.cs
@@ -8,9 +8,14 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Adds the FloatingWindow services to the service collection.
     /// </summary>
-    public static IServiceCollection AddFloatingWindow(this IServiceCollection services)
+    /// <param name="services">The service collection.</param>
+    /// <param name="assetRoot">Static-asset path segment, e.g. "_content/SqliteWasmBlazor.FloatingWindow/". Override for browser-extension builds.</param>
+    public static IServiceCollection AddFloatingWindow(
+        this IServiceCollection services,
+        string assetRoot = "_content/SqliteWasmBlazor.FloatingWindow/")
     {
         services.AddScoped<IWindowManager, WindowManager>();
+        services.AddSingleton(new FloatingWindowOptions { AssetRoot = assetRoot });
         return services;
     }
 }

--- a/SqliteWasmBlazor.FloatingWindow/FloatingWindowOptions.cs
+++ b/SqliteWasmBlazor.FloatingWindow/FloatingWindowOptions.cs
@@ -1,0 +1,14 @@
+namespace SqliteWasmBlazor.FloatingWindow;
+
+/// <summary>
+/// Options for the FloatingWindow package. Register via <c>AddFloatingWindow(assetRoot: ...)</c>.
+/// </summary>
+public sealed class FloatingWindowOptions
+{
+    /// <summary>
+    /// Path prefix for static assets, e.g. "_content/SqliteWasmBlazor.FloatingWindow/".
+    /// Override for browser-extension builds where Blazor.BrowserExtension flattens the
+    /// path (e.g. "content/SqliteWasmBlazor.FloatingWindow/").
+    /// </summary>
+    public string AssetRoot { get; init; } = "_content/SqliteWasmBlazor.FloatingWindow/";
+}

--- a/SqliteWasmBlazor.TestApp/Program.cs
+++ b/SqliteWasmBlazor.TestApp/Program.cs
@@ -46,14 +46,10 @@ builder.Services.AddDbContextFactory<TodoDbContext>(options =>
 // Register SqliteWasm database management service
 builder.Services.AddSqliteWasm();
 
-// Derive the base href from the app's base address so sub-path deployments
-// (e.g. <base href="/myapp/">) are handled correctly without DOM inspection.
-var baseHref = new Uri(builder.HostEnvironment.BaseAddress).AbsolutePath;
-
 var host = builder.Build();
 
 // Initialize sqlite-wasm worker
-await host.Services.InitializeSqliteWasmAsync(baseHref: baseHref);
+await host.Services.InitializeSqliteWasmAsync(builder.HostEnvironment);
 
 // Initialize database - always recreate for clean test runs
 using (var scope = host.Services.CreateScope())

--- a/SqliteWasmBlazor.TestApp/Program.cs
+++ b/SqliteWasmBlazor.TestApp/Program.cs
@@ -46,10 +46,14 @@ builder.Services.AddDbContextFactory<TodoDbContext>(options =>
 // Register SqliteWasm database management service
 builder.Services.AddSqliteWasm();
 
+// Derive the base href from the app's base address so sub-path deployments
+// (e.g. <base href="/myapp/">) are handled correctly without DOM inspection.
+var baseHref = new Uri(builder.HostEnvironment.BaseAddress).AbsolutePath;
+
 var host = builder.Build();
 
 // Initialize sqlite-wasm worker
-await host.Services.InitializeSqliteWasmAsync();
+await host.Services.InitializeSqliteWasmAsync(baseHref: baseHref);
 
 // Initialize database - always recreate for clean test runs
 using (var scope = host.Services.CreateScope())

--- a/SqliteWasmBlazor.TestApp/wwwroot/index.html
+++ b/SqliteWasmBlazor.TestApp/wwwroot/index.html
@@ -5,6 +5,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SqliteWasmBlazor.TestApp</title>
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'">
     <base href="/" />
     <link rel="stylesheet" href="css/app.css" />
     <link rel="icon" type="image/png" href="favicon.png" />

--- a/SqliteWasmBlazor.TestHost/Program.cs
+++ b/SqliteWasmBlazor.TestHost/Program.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Configure logging - suppress verbose output during tests
@@ -9,6 +11,64 @@ builder.Logging.SetMinimumLevel(LogLevel.Warning);
 builder.Services.AddRazorPages();
 
 var app = builder.Build();
+
+// Support sub-path deployment (e.g. BLAZOR_BASE_PATH=/myapp) for E2E testing.
+// UsePathBase strips the prefix from every incoming request so static asset and
+// routing middleware don't need to know about it.
+var basePath = app.Configuration["BLAZOR_BASE_PATH"] ?? "";
+if (!string.IsNullOrEmpty(basePath))
+{
+    app.UsePathBase(basePath);
+
+    // Rewrite <base href="/"> in HTML responses so Blazor WASM derives the correct
+    // HostEnvironment.BaseAddress (and therefore the correct baseHref for the worker bridge).
+    // We strip Accept-Encoding for potential HTML requests so MapStaticAssets serves the
+    // uncompressed version that we can safely read and modify as a string.
+    app.Use(async (context, next) =>
+    {
+        var path = context.Request.Path.Value ?? "";
+        var couldBeHtml = path == "/"
+                          || path.EndsWith(".html", StringComparison.OrdinalIgnoreCase)
+                          || !Path.HasExtension(path);
+
+        if (!couldBeHtml)
+        {
+            await next(context);
+            return;
+        }
+
+        // Suppress compressed delivery so we receive plain-text HTML from MapStaticAssets
+        context.Request.Headers["Accept-Encoding"] = "";
+
+        var originalBody = context.Response.Body;
+        await using var buffer = new MemoryStream();
+        context.Response.Body = buffer;
+
+        try
+        {
+            await next(context);
+        }
+        finally
+        {
+            context.Response.Body = originalBody;
+        }
+
+        buffer.Position = 0;
+        var contentType = context.Response.ContentType ?? "";
+        if (context.Response.StatusCode == 200 && contentType.StartsWith("text/html"))
+        {
+            var html = await new StreamReader(buffer, Encoding.UTF8).ReadToEndAsync();
+            html = html.Replace("<base href=\"/\"", $"<base href=\"{basePath}/\"");
+            var bytes = Encoding.UTF8.GetBytes(html);
+            context.Response.ContentLength = bytes.Length;
+            await originalBody.WriteAsync(bytes);
+        }
+        else
+        {
+            await buffer.CopyToAsync(originalBody);
+        }
+    });
+}
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
@@ -32,6 +92,7 @@ app.MapControllers();
 app.MapFallbackToFile("index.html");
 
 app.Run();
+
 
 // Make Program accessible to test project
 namespace SqliteWasmBlazor.TestHost

--- a/SqliteWasmBlazor.TestHost/Program.cs
+++ b/SqliteWasmBlazor.TestHost/Program.cs
@@ -20,13 +20,13 @@ if (!string.IsNullOrEmpty(basePath))
 {
     app.UsePathBase(basePath);
 
-    // Rewrite <base href="/"> in HTML responses so Blazor WASM derives the correct
-    // HostEnvironment.BaseAddress (and therefore the correct baseHref for the worker bridge).
-    // We strip Accept-Encoding for potential HTML requests so MapStaticAssets serves the
-    // uncompressed version that we can safely read and modify as a string.
+    // NOTE: test-only scaffolding — not production-ready.
+    // Buffers and rewrites HTML responses so the test app boots correctly under a sub-path.
     app.Use(async (context, next) =>
     {
         var path = context.Request.Path.Value ?? "";
+        // Matches "/", "*.html", and extensionless paths (not just HTML) —
+        // intentional; over-buffering has no observable side-effect in tests.
         var couldBeHtml = path == "/"
                           || path.EndsWith(".html", StringComparison.OrdinalIgnoreCase)
                           || !Path.HasExtension(path);
@@ -37,7 +37,7 @@ if (!string.IsNullOrEmpty(basePath))
             return;
         }
 
-        // Suppress compressed delivery so we receive plain-text HTML from MapStaticAssets
+        // Strip Accept-Encoding (couldBeHtml paths only) so MapStaticAssets serves plain text.
         context.Request.Headers["Accept-Encoding"] = "";
 
         var originalBody = context.Response.Body;
@@ -58,6 +58,7 @@ if (!string.IsNullOrEmpty(basePath))
         if (context.Response.StatusCode == 200 && contentType.StartsWith("text/html"))
         {
             var html = await new StreamReader(buffer, Encoding.UTF8).ReadToEndAsync();
+            // Rewrites the root-href literal; test apps always start with <base href="/>".
             html = html.Replace("<base href=\"/\"", $"<base href=\"{basePath}/\"");
             var bytes = Encoding.UTF8.GetBytes(html);
             context.Response.ContentLength = bytes.Length;
@@ -92,8 +93,6 @@ app.MapControllers();
 app.MapFallbackToFile("index.html");
 
 app.Run();
-
-
 // Make Program accessible to test project
 namespace SqliteWasmBlazor.TestHost
 {

--- a/SqliteWasmBlazor.Tests/Infrastructure/BrowserFixtures.cs
+++ b/SqliteWasmBlazor.Tests/Infrastructure/BrowserFixtures.cs
@@ -1,4 +1,40 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+
 namespace SqliteWasmBlazor.Tests.Infrastructure;
+
+/// <summary>
+/// Fixture that serves the TestApp under a sub-path (/myapp) to exercise
+/// the baseHref parameter introduced by the CSP-hardening change.
+/// </summary>
+public class SubPathFixture : WaFixtureBase, IWaFixture
+{
+    /// <summary>The path base used for sub-path deployment testing.</summary>
+    public const string SubPath = "/myapp";
+
+    private static int PortNumber => 7054;
+
+    public IWaFixture.BrowserType Type => IWaFixture.BrowserType.CHROMIUM;
+    public int Port => PortNumber;
+    public bool OnePass => false;
+    public bool Headless => true;
+
+    public SubPathFixture() : base(PortNumber) { }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        base.ConfigureWebHost(builder);
+        // Inject BLAZOR_BASE_PATH so the TestHost rewrites <base href> in index.html
+        // and applies UsePathBase, enabling a realistic sub-path deployment.
+        builder.ConfigureAppConfiguration(config =>
+            config.AddInMemoryCollection(new Dictionary<string, string?> { ["BLAZOR_BASE_PATH"] = SubPath }));
+    }
+
+    public async Task InitializeAsync()
+    {
+        await InitializeAsync(Type, OnePass, Headless);
+    }
+}
 
 public class ChromiumFixture : WaFixtureBase, IWaFixture
 {

--- a/SqliteWasmBlazor.Tests/SubPathTests.cs
+++ b/SqliteWasmBlazor.Tests/SubPathTests.cs
@@ -1,0 +1,73 @@
+using Microsoft.Playwright;
+using SqliteWasmBlazor.Tests.Infrastructure;
+using Xunit.Abstractions;
+
+namespace SqliteWasmBlazor.Tests;
+
+/// <summary>
+/// E2E test that verifies the library works when the Blazor app is deployed under
+/// a sub-path (e.g. /myapp/). This validates that:
+///   1. The response-rewriting middleware serves index.html with the correct <base href="/myapp/">.
+///   2. TestApp derives baseHref from HostEnvironment.BaseAddress ("/myapp/").
+///   3. SqliteWasmWorkerBridge loads sqlite-wasm-bridge.js from /myapp/_content/...
+///      instead of via the now-CSP-blocked data:text/javascript scheme.
+///   4. No CSP violations are triggered during the full lifecycle.
+/// </summary>
+[CollectionDefinition("SubPath", DisableParallelization = true)]
+public class SubPathCollection : ICollectionFixture<SubPathFixture>
+{
+    // Marker class — no code needed.
+}
+
+[Collection("SubPath")]
+public class SubPathTest(SubPathFixture fixture, ITestOutputHelper output) : IAsyncLifetime
+{
+    private readonly List<string> _cspViolations = [];
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    public async Task InitializeAsync()
+    {
+        await fixture.InitializeAsync();
+
+        // Capture any CSP violation reports or "Refused to" console errors.
+        // A regression (e.g. using data:text/javascript again) would show up here.
+        fixture.Page!.Console += (_, msg) =>
+        {
+            if (msg.Type == "error" &&
+                (msg.Text.Contains("Content Security Policy", StringComparison.OrdinalIgnoreCase) ||
+                 msg.Text.Contains("Refused to", StringComparison.OrdinalIgnoreCase)))
+            {
+                _cspViolations.Add(msg.Text);
+                output.WriteLine($"[CSP VIOLATION] {msg.Text}");
+            }
+        };
+    }
+
+    [Theory]
+    [InlineData("Create_SingleEntity")]
+    [InlineData("Read_ById")]
+    [InlineData("Transaction_Commit")]
+    public async Task SubPath_TestCaseAsync(string name)
+    {
+        Assert.NotNull(fixture.Page);
+
+        var url = $"http://localhost:{fixture.Port}{SubPathFixture.SubPath}/Tests/{name}";
+        output.WriteLine($"Navigating to: {url}");
+
+        await fixture.Page.GotoAsync(url);
+
+        var successLocator = fixture.Page.Locator($"text=SqliteWasm -> {name}: OK");
+        var skippedLocator = fixture.Page.Locator($"text=SqliteWasm -> {name}: SKIPPED");
+
+        // Allow 30 s for WASM initialisation + test execution (same as ChromiumTest)
+        var options = new LocatorAssertionsToBeVisibleOptions { Timeout = 30000 };
+
+        await Task.WhenAny(
+            Assertions.Expect(successLocator).ToBeVisibleAsync(options),
+            Assertions.Expect(skippedLocator).ToBeVisibleAsync(options)
+        );
+
+        Assert.Empty(_cspViolations);
+    }
+}

--- a/SqliteWasmBlazor/Extensions/SqliteWasmServiceCollectionExtensions.cs
+++ b/SqliteWasmBlazor/Extensions/SqliteWasmServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 // SqliteWasmBlazor - Minimal EF Core compatible provider
 // MIT License
 
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -29,18 +30,20 @@ public static class SqliteWasmServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The service collection.</param>
     /// <param name="baseHref">Base href of the Blazor app (e.g. "/" or "/myapp/"). Defaults to "/".</param>
+    /// <param name="assetRoot">Static-asset path segment, e.g. "_content/SqliteWasmBlazor/". Override for browser-extension builds.</param>
     /// <param name="cancellationToken">Optional cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     /// <exception cref="InvalidOperationException">Thrown when initialization fails or database is locked by another tab.</exception>
     public static async Task InitializeSqliteWasmAsync(
         this IServiceProvider services,
         string baseHref = "/",
+        string assetRoot = "_content/SqliteWasmBlazor/",
         CancellationToken cancellationToken = default)
     {
         try
         {
             // Initialize the worker bridge
-            await SqliteWasmWorkerBridge.Instance.InitializeAsync(baseHref, cancellationToken);
+            await SqliteWasmWorkerBridge.Instance.InitializeAsync(baseHref, assetRoot, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -55,15 +58,35 @@ Please close any other tabs running this application and refresh the page.
     }
 
     /// <summary>
+    /// Initializes the SqliteWasm worker bridge without Entity Framework Core.
+    /// Derives the base href from <paramref name="environment"/>.<see cref="IWebAssemblyHostEnvironment.BaseAddress"/> — the recommended path for sub-path deployments.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="environment">The host environment. Provides <see cref="IWebAssemblyHostEnvironment.BaseAddress"/>, which already reflects the <c>&lt;base href&gt;</c> baked in at build time.</param>
+    /// <param name="assetRoot">Static-asset path segment, e.g. "_content/SqliteWasmBlazor/". Override for browser-extension builds.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    public static Task InitializeSqliteWasmAsync(
+        this IServiceProvider services,
+        IWebAssemblyHostEnvironment environment,
+        string assetRoot = "_content/SqliteWasmBlazor/",
+        CancellationToken cancellationToken = default)
+    {
+        var baseHref = new Uri(environment.BaseAddress).AbsolutePath;
+        return services.InitializeSqliteWasmAsync(baseHref, assetRoot, cancellationToken);
+    }
+
+    /// <summary>
     /// Initializes the SqliteWasm database by applying pending migrations and handling migration history recovery.
     /// </summary>
     /// <typeparam name="TContext">The DbContext type to initialize.</typeparam>
     /// <param name="services">The service collection.</param>
     /// <param name="baseHref">Base href of the Blazor app (e.g. "/" or "/myapp/"). Defaults to "/".</param>
+    /// <param name="assetRoot">Static-asset path segment, e.g. "_content/SqliteWasmBlazor/". Override for browser-extension builds.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     public static async Task InitializeSqliteWasmDatabaseAsync<TContext>(
         this IServiceProvider services,
-        string baseHref = "/")
+        string baseHref = "/",
+        string assetRoot = "_content/SqliteWasmBlazor/")
         where TContext : DbContext
     {
         var initService = services.GetRequiredService<IDBInitializationService>();
@@ -71,7 +94,7 @@ Please close any other tabs running this application and refresh the page.
         try
         {
             // Initialize the worker bridge first
-            await SqliteWasmWorkerBridge.Instance.InitializeAsync(baseHref);
+            await SqliteWasmWorkerBridge.Instance.InitializeAsync(baseHref, assetRoot);
         }
         catch (Exception ex)
         {
@@ -137,6 +160,24 @@ Please close any other tabs running this application and refresh the page.
             initService.ErrorMessage += Environment.NewLine;
             initService.ErrorMessage += $"{ex.StackTrace}";
         }
+    }
+
+    /// <summary>
+    /// Initializes the SqliteWasm database by applying pending migrations and handling migration history recovery.
+    /// Derives the base href from <paramref name="environment"/>.<see cref="IWebAssemblyHostEnvironment.BaseAddress"/> — the recommended path for sub-path deployments.
+    /// </summary>
+    /// <typeparam name="TContext">The DbContext type to initialize.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <param name="environment">The host environment. Provides <see cref="IWebAssemblyHostEnvironment.BaseAddress"/>, which already reflects the <c>&lt;base href&gt;</c> baked in at build time.</param>
+    /// <param name="assetRoot">Static-asset path segment, e.g. "_content/SqliteWasmBlazor/". Override for browser-extension builds.</param>
+    public static Task InitializeSqliteWasmDatabaseAsync<TContext>(
+        this IServiceProvider services,
+        IWebAssemblyHostEnvironment environment,
+        string assetRoot = "_content/SqliteWasmBlazor/")
+        where TContext : DbContext
+    {
+        var baseHref = new Uri(environment.BaseAddress).AbsolutePath;
+        return services.InitializeSqliteWasmDatabaseAsync<TContext>(baseHref, assetRoot);
     }
 
     /// <summary>

--- a/SqliteWasmBlazor/Extensions/SqliteWasmServiceCollectionExtensions.cs
+++ b/SqliteWasmBlazor/Extensions/SqliteWasmServiceCollectionExtensions.cs
@@ -28,17 +28,19 @@ public static class SqliteWasmServiceCollectionExtensions
     /// Use this method when using the ADO.NET provider directly without EF Core.
     /// </summary>
     /// <param name="services">The service collection.</param>
+    /// <param name="baseHref">Base href of the Blazor app (e.g. "/" or "/myapp/"). Defaults to "/".</param>
     /// <param name="cancellationToken">Optional cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     /// <exception cref="InvalidOperationException">Thrown when initialization fails or database is locked by another tab.</exception>
     public static async Task InitializeSqliteWasmAsync(
         this IServiceProvider services,
+        string baseHref = "/",
         CancellationToken cancellationToken = default)
     {
         try
         {
             // Initialize the worker bridge
-            await SqliteWasmWorkerBridge.Instance.InitializeAsync(cancellationToken);
+            await SqliteWasmWorkerBridge.Instance.InitializeAsync(baseHref, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -57,9 +59,11 @@ Please close any other tabs running this application and refresh the page.
     /// </summary>
     /// <typeparam name="TContext">The DbContext type to initialize.</typeparam>
     /// <param name="services">The service collection.</param>
+    /// <param name="baseHref">Base href of the Blazor app (e.g. "/" or "/myapp/"). Defaults to "/".</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     public static async Task InitializeSqliteWasmDatabaseAsync<TContext>(
-        this IServiceProvider services)
+        this IServiceProvider services,
+        string baseHref = "/")
         where TContext : DbContext
     {
         var initService = services.GetRequiredService<IDBInitializationService>();
@@ -67,7 +71,7 @@ Please close any other tabs running this application and refresh the page.
         try
         {
             // Initialize the worker bridge first
-            await SqliteWasmWorkerBridge.Instance.InitializeAsync();
+            await SqliteWasmWorkerBridge.Instance.InitializeAsync(baseHref);
         }
         catch (Exception ex)
         {

--- a/SqliteWasmBlazor/Services/SqliteWasmWorkerBridge.cs
+++ b/SqliteWasmBlazor/Services/SqliteWasmWorkerBridge.cs
@@ -74,22 +74,18 @@ internal sealed partial class SqliteWasmWorkerBridge : ISqliteWasmDatabaseServic
     {
     }
 
-    [JSImport("getBaseHref", "SqliteWasmBlazor")]
-    private static partial string GetBaseHref();
-
     /// <summary>
     /// Initialize the worker and sqlite-wasm module.
     /// </summary>
-    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    /// <param name="baseHref">The base href path (e.g. "/" or "/myapp/"). Pass <see cref="Microsoft.AspNetCore.Components.NavigationManager.BaseUri"/> resolved to a path. Defaults to "/".</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task InitializeAsync(string baseHref = "/", CancellationToken cancellationToken = default)
     {
         if (_isInitialized)
         {
             return;
         }
 
-        // Get base href dynamically and construct absolute path
-        await JSHost.ImportAsync("SqliteWasmBlazor", "data:text/javascript,export function getBaseHref() { return document.querySelector('base')?.getAttribute('href') || '/'; }");
-        var baseHref = GetBaseHref();
         var bridgePath = $"{baseHref}_content/SqliteWasmBlazor/sqlite-wasm-bridge.js";
 
         await JSHost.ImportAsync("sqliteWasmWorker", bridgePath, cancellationToken);
@@ -496,7 +492,7 @@ internal sealed partial class SqliteWasmWorkerBridge : ISqliteWasmDatabaseServic
     {
         if (!_isInitialized)
         {
-            await InitializeAsync(cancellationToken);
+            await InitializeAsync("/", cancellationToken);
         }
     }
 

--- a/SqliteWasmBlazor/Services/SqliteWasmWorkerBridge.cs
+++ b/SqliteWasmBlazor/Services/SqliteWasmWorkerBridge.cs
@@ -44,6 +44,9 @@ internal sealed partial class SqliteWasmWorkerBridge : ISqliteWasmDatabaseServic
     private int _nextRequestId;
     private bool _isInitialized;
     private static TaskCompletionSource<bool>? _initializationTcs;
+    // Cached so EnsureInitializedAsync retries with the correct paths on failure/retry.
+    private string _baseHref = "/";
+    private string _assetRoot = "_content/SqliteWasmBlazor/";
 
     /// <summary>
     /// Checks if the worker has a database open. Used by SqliteWasmConnection
@@ -78,22 +81,30 @@ internal sealed partial class SqliteWasmWorkerBridge : ISqliteWasmDatabaseServic
     /// Initialize the worker and sqlite-wasm module.
     /// </summary>
     /// <param name="baseHref">The base href path (e.g. "/" or "/myapp/"). Pass <see cref="Microsoft.AspNetCore.Components.NavigationManager.BaseUri"/> resolved to a path. Defaults to "/".</param>
+    /// <param name="assetRoot">Path segment between <paramref name="baseHref"/> and the individual file names, e.g. "_content/SqliteWasmBlazor/". Override for browser-extension builds where Blazor.BrowserExtension flattens the path to "content/SqliteWasmBlazor/".</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    public async Task InitializeAsync(string baseHref = "/", CancellationToken cancellationToken = default)
+    public async Task InitializeAsync(string baseHref = "/", string assetRoot = "_content/SqliteWasmBlazor/", CancellationToken cancellationToken = default)
     {
+        // Cache before the _isInitialized guard so retries use the correct paths.
+        _baseHref = baseHref;
+        _assetRoot = assetRoot;
+
         if (_isInitialized)
         {
             return;
         }
 
-        var bridgePath = $"{baseHref}_content/SqliteWasmBlazor/sqlite-wasm-bridge.js";
+        var bridgePath = $"{baseHref}{assetRoot}sqlite-wasm-bridge.js";
 
         await JSHost.ImportAsync("sqliteWasmWorker", bridgePath, cancellationToken);
 
-        // Wait for worker to signal ready or error
+        // Set TCS before calling InitializeBridge so OnWorkerReady/OnWorkerError always have a valid target.
         _initializationTcs = new TaskCompletionSource<bool>();
         var token = cancellationToken;
         await using var registration = token.Register(() => _initializationTcs.TrySetCanceled());
+
+        // Creates the worker via JSImport (replaces the DOM-reading IIFE; CSP-safe in all contexts).
+        InitializeBridge(baseHref, assetRoot);
 
         // Worker will call OnWorkerReady() or OnWorkerError() via JSExport
         var ready = await _initializationTcs.Task;
@@ -492,7 +503,7 @@ internal sealed partial class SqliteWasmWorkerBridge : ISqliteWasmDatabaseServic
     {
         if (!_isInitialized)
         {
-            await InitializeAsync("/", cancellationToken);
+            await InitializeAsync(_baseHref, _assetRoot, cancellationToken);
         }
     }
 
@@ -787,6 +798,9 @@ internal sealed partial class SqliteWasmWorkerBridge : ISqliteWasmDatabaseServic
     {
         _initializationTcs?.TrySetException(new InvalidOperationException($"Worker initialization failed: {error}"));
     }
+
+    [JSImport("initializeBridge", "sqliteWasmWorker")]
+    private static partial void InitializeBridge(string baseHref, string assetRoot);
 
     [JSImport("sendToWorker", "sqliteWasmWorker")]
     private static partial void SendToWorker(string messageJson);

--- a/SqliteWasmBlazor/SqliteWasmBlazor.csproj
+++ b/SqliteWasmBlazor/SqliteWasmBlazor.csproj
@@ -57,6 +57,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5" />
     <PackageReference Include="MessagePack" Version="$(MessagePackVersion)" />
     <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="$(SqlitePCLRawVersion)" ExcludeAssets="all" PrivateAssets="all" />
   </ItemGroup>

--- a/SqliteWasmBlazor/TypeScript/sqlite-worker.ts
+++ b/SqliteWasmBlazor/TypeScript/sqlite-worker.ts
@@ -49,6 +49,8 @@ const MODULE_NAME = 'SQLite Worker';
 
 // Store base href from main thread
 let baseHref = '/';
+// Asset root (e.g. "_content/SqliteWasmBlazor/"). Override for browser-extension builds.
+let assetRoot = '_content/SqliteWasmBlazor/';
 
 // Helper function to convert BigInt and Uint8Array for JSON serialization
 // BigInts within safe integer range (±2^53-1) are converted to number for efficiency
@@ -105,7 +107,7 @@ async function initializeSQLite() {
             locateFile(path: string) {
                 // Tell sqlite-wasm where to find the wasm file using base href
                 if (path.endsWith('.wasm')) {
-                    return `${baseHref}_content/SqliteWasmBlazor/${path}`;
+                    return `${baseHref}${assetRoot}${path}`;
                 }
                 return path;
             }
@@ -157,11 +159,11 @@ async function initializeSQLite() {
 }
 
 // Handle messages from main thread
-self.onmessage = async (event: MessageEvent<WorkerRequest | { type: 'setLogLevel'; level: number } | { type: 'init'; baseHref: string }>) => {
-    // Handle initialization with base href
+self.onmessage = async (event: MessageEvent<WorkerRequest | { type: 'setLogLevel'; level: number } | { type: 'init'; baseHref: string; assetRoot: string }>) => {
+    // Handle initialization with base href and asset root
     if ('type' in event.data && event.data.type === 'init' && 'baseHref' in event.data) {
         baseHref = event.data.baseHref;
-        // Start initialization after receiving base href
+        assetRoot = event.data.assetRoot;
         await initializeSQLite();
         return;
     }

--- a/SqliteWasmBlazor/TypeScript/worker-bridge.ts
+++ b/SqliteWasmBlazor/TypeScript/worker-bridge.ts
@@ -13,18 +13,18 @@ interface IMemoryView {
 
 let worker: Worker | null = null;
 
-// Initialize worker on first import
-(async () => {
+// Called from C# (JSImport) to create the worker with explicit asset paths.
+// Avoids reading <base href> from the DOM, which is blocked by strict CSP and
+// unreliable in browser-extension contexts.
+export function initializeBridge(baseHref: string, assetRoot: string): void {
     try {
-        // Create worker - load from static assets path using base href
-        const baseHref = document.querySelector('base')?.getAttribute('href') || '/';
         worker = new Worker(
-            `${baseHref}_content/SqliteWasmBlazor/sqlite-wasm-worker.js`,
+            `${baseHref}${assetRoot}sqlite-wasm-worker.js`,
             { type: 'module' }
         );
 
-        // Send base href to worker so it can locate WASM files
-        worker.postMessage({ type: 'init', baseHref });
+        // Pass both paths so the worker can locate .wasm and other assets.
+        worker.postMessage({ type: 'init', baseHref, assetRoot });
 
         // Handle messages from worker
         worker.onmessage = async (event) => {
@@ -97,8 +97,17 @@ let worker: Worker | null = null;
 
     } catch (error) {
         console.error('[Worker Bridge] Failed to create worker:', error);
+        // Notify C# so InitializeAsync throws instead of timing out.
+        try {
+            const exports = await (globalThis as any).getDotnetRuntime(0).getAssemblyExports("SqliteWasmBlazor.dll");
+            exports.SqliteWasmBlazor.SqliteWasmWorkerBridge.OnWorkerError(
+                error instanceof Error ? error.message : 'Failed to create worker'
+            );
+        } catch {
+            // Runtime not yet available — nothing more we can do.
+        }
     }
-})();
+}
 
 // Called from C# to send request to worker
 export function sendToWorker(messageJson: string): void {
@@ -144,6 +153,7 @@ export const logger = {
 
 // Make functions available to C# JSImport
 (globalThis as any).sqliteWasmWorker = {
+    initializeBridge,
     sendToWorker,
     sendBinaryToWorker
 };

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -221,3 +221,26 @@ await DatabaseService.ImportDatabaseAsync("TodoDb.db", data);
 ```
 
 See [Changelog](../CHANGELOG.md#raw-database-importexport) for full implementation details.
+
+## Deploying Under a Sub-path
+
+To host at a non-root path (e.g. `/myapp/`), pass the host environment at startup — the library derives the base href from `HostEnvironment.BaseAddress`, which Blazor already sets from `<base href>`:
+
+```csharp
+// Program.cs
+var host = builder.Build();
+await host.Services.InitializeSqliteWasmAsync(builder.HostEnvironment);        // ADO.NET
+await host.Services.InitializeSqliteWasmDatabaseAsync<MyDbContext>(builder.HostEnvironment); // EF Core
+```
+
+Using the default `"/"` on a sub-path deployment will silently 404 the worker bridge.
+
+### Browser-extension builds
+
+Blazor.BrowserExtension flattens `_content/SqliteWasmBlazor/` to `content/SqliteWasmBlazor/`. Override `assetRoot`:
+
+```csharp
+await host.Services.InitializeSqliteWasmAsync(baseHref, assetRoot: "content/SqliteWasmBlazor/");
+```
+
+The same `assetRoot` parameter is available on `InitializeSqliteWasmDatabaseAsync` and on `.Components`/`.FloatingWindow`.


### PR DESCRIPTION
# CSP Hardening & Configurable Base Href

Removes the `data:text/javascript` JS import used to auto-detect `<base href>` — blocked by a strict CSP — and replaces it with an explicit `baseHref` parameter (default `"/"`).

## Changes

- **`index.html` (AdoNetSample, Demo, TestApp):** Added `Content-Security-Policy` meta tag. Notably `script-src 'self' 'wasm-unsafe-eval'` — no `data:`, `object-src 'none'`, `base-uri 'self'`.
- **`SqliteWasmWorkerBridge.InitializeAsync`:** Removed `JSHost.ImportAsync("data:text/javascript,...")` and the `[JSImport]` stub. Accepts `string baseHref = "/"` instead.
- **`SqliteWasmServiceCollectionExtensions`:** Both `InitializeSqliteWasmAsync` and `InitializeSqliteWasmDatabaseAsync<TContext>` now forward an optional `baseHref` to the bridge.

**Migration:** Apps on a sub-path must now pass `baseHref` explicitly:
```csharp
await app.Services.InitializeSqliteWasmAsync(baseHref: "/myapp/");
```

## Tests

Added `SubPathTests` — 3 Playwright E2E tests running the full TestApp under `/myapp/` (via `SubPathFixture`). Covers the complete `baseHref` chain: rewritten `<base href>` → `HostEnvironment.BaseAddress` → `InitializeSqliteWasmAsync(baseHref)` → correct bridge URL. Each test also asserts zero CSP violation console errors, which catches a regression to `data:text/javascript`.